### PR TITLE
Implemented: Unification variables in REPL

### DIFF
--- a/src/Lang/Core.mli
+++ b/src/Lang/Core.mli
@@ -48,6 +48,9 @@ end
 
 (** Types, indexed by a type-represented kind *)
 type _ typ =
+  | TUVar : UID.t * 'k kind -> 'k typ
+    (** UVar type kept for pretty printing *)
+
   | TEffPure : keffect typ
     (** Pure effect *)
 

--- a/src/Lang/CorePriv/Effect.ml
+++ b/src/Lang/CorePriv/Effect.ml
@@ -16,7 +16,7 @@ let rec join eff1 eff2 =
   | TEffJoin(eff_a, eff_b), _ ->
     join eff_a (join eff_b eff2)
 
-  | (TVar _ | TApp _), _ ->
+  | (TVar _ | TApp _ | TUVar _), _ ->
     if Type.simple_subeffect eff1 eff2 then eff2
     else TEffJoin(eff1, eff2)
 
@@ -34,4 +34,4 @@ let rec is_pure eff =
   match eff with
   | TEffPure -> true
   | TEffJoin(eff1, eff2) -> is_pure eff1 && is_pure eff2
-  | TVar _ | TApp _ -> false
+  | TUVar _ | TVar _ | TApp _ -> false

--- a/src/Lang/CorePriv/Subst.ml
+++ b/src/Lang/CorePriv/Subst.ml
@@ -33,7 +33,7 @@ let add_tvars sub xs =
 let rec in_type_rec : type k. t -> k typ -> k typ =
   fun sub tp ->
   match tp with
-  | TEffPure -> tp
+  | TUVar _ | TEffPure -> tp
   | TEffJoin(eff1, eff2) ->
     TEffJoin(in_type_rec sub eff1, in_type_rec sub eff2)
   | TVar x ->

--- a/src/Lang/CorePriv/TypeBase.ml
+++ b/src/Lang/CorePriv/TypeBase.ml
@@ -79,6 +79,7 @@ end
 type 'k tvar = 'k TVar.t
 
 type _ typ =
+  | TUVar    : UID.t * 'k kind -> 'k typ
   | TEffPure : keffect typ
   | TEffJoin : effect * effect -> keffect typ
   | TVar     : 'k tvar -> 'k typ

--- a/src/Lang/CorePriv/WellTypedInvariant.ml
+++ b/src/Lang/CorePriv/WellTypedInvariant.ml
@@ -114,6 +114,9 @@ end
 let rec tr_type : type k. Env.t -> k typ -> k typ =
   fun env tp ->
   match tp with
+  | TUVar _ ->
+    InterpLib.InternalError.report
+      ~reason:"Unsolved unification variables left." ();
   | TEffPure -> TEffPure
   | TEffJoin(eff1, eff2) ->
     TEffJoin(tr_type env eff1, tr_type env eff2)
@@ -213,6 +216,9 @@ let rec infer_type_eff env e =
     | TArrow(tp2, tp1, eff) ->
       check_vtype env v2 tp2;
       (tp1, eff)
+    | TUVar _ ->
+      InterpLib.InternalError.report
+        ~reason:"Unsolved unification variables left." ();
     | TVar _ | TForall _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
@@ -224,6 +230,9 @@ let rec infer_type_eff env e =
       | Equal    -> (Type.subst_type x tp body, TEffPure)
       | NotEqual -> failwith "Internal kind error"
       end
+    | TUVar _ ->
+      InterpLib.InternalError.report
+        ~reason:"Unsolved unification variables left." ();
     | TVar _ | TArrow _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
@@ -291,6 +300,9 @@ let rec infer_type_eff env e =
       check_type_eff env body tp0 eff0;
       (tp, eff)
 
+    | TUVar _ ->
+      InterpLib.InternalError.report
+        ~reason:"Unsolved unification variables left." ();
     | TVar _ | TArrow _ | TForall _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
@@ -303,6 +315,9 @@ let rec infer_type_eff env e =
       check_type_eff env ret tp0 eff0;
       (tp0, eff0)
 
+    | TUVar _ ->
+      InterpLib.InternalError.report
+        ~reason:"Unsolved unification variables left." ();
     | TVar _ | TArrow _ | TForall _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end

--- a/src/Pipeline.ml
+++ b/src/Pipeline.ml
@@ -13,27 +13,28 @@ let dump_sexpr flag to_sexpr p =
     SExpr.pretty_stdout (to_sexpr p);
   p
 
-let check_invariant inv p =
-  inv p;
+let check_invariant check inv p =
+  if check
+  then inv p;
   p
 
 let add_prelude p =
   if !use_prelude then Parser.Main.parse_lib Config.prelude_path p else p
 
-let common_pipeline prog =
+let common_pipeline repl_mode prog =
   prog
   |> add_prelude
   |> TypeInference.Main.tr_program
-  |> ToCore.Main.tr_program
+  |> ToCore.Main.tr_program ~repl_mode
   |> dump_sexpr !dump_core Lang.Core.to_sexpr
-  |> check_invariant Lang.Core.check_well_typed
+  |> check_invariant (not repl_mode) Lang.Core.check_well_typed
   |> TypeErase.tr_program
   |> Eval.eval_program
 
 let run_repl () =
   Parser.Main.repl
-  |> common_pipeline
+  |> common_pipeline true
 
 let run_file fname =
   Parser.Main.parse_file fname
-  |> common_pipeline
+  |> common_pipeline false

--- a/src/ToCore/Env.ml
+++ b/src/ToCore/Env.ml
@@ -7,20 +7,22 @@
 open Common
 
 type t =
-  { tvar_map : T.TVar.ex S.TVar.Map.t
+  { tvar_map  : T.TVar.ex S.TVar.Map.t;
+    repl_mode : bool;
   }
 
-let empty =
+let empty ~repl_mode =
   { tvar_map =
       S.BuiltinType.all
       |> List.map (fun (name, x) -> (x, List.assoc name T.BuiltinType.all))
-      |> List.to_seq |> S.TVar.Map.of_seq
+    |> List.to_seq |> S.TVar.Map.of_seq;
+    repl_mode;
   }
 
 let add_tvar env x =
   let (Ex k) = tr_kind (S.TVar.kind x) in
   let y = T.TVar.Ex (T.TVar.fresh k) in
-  { tvar_map = S.TVar.Map.add x y env.tvar_map
+  { env with tvar_map = S.TVar.Map.add x y env.tvar_map
   }, y
 
 let add_named_tvar env (_, x) =
@@ -30,7 +32,7 @@ let add_tvars env xs =
   List.fold_left_map add_tvar env xs
 
 let add_tvar_ex' env x y =
-  { tvar_map = S.TVar.Map.add x y env.tvar_map }
+  { env with tvar_map = S.TVar.Map.add x y env.tvar_map }
 
 let add_tvars' env xs ys =
   List.fold_left2 add_tvar_ex' env xs ys
@@ -39,3 +41,5 @@ let lookup_tvar env x =
   try S.TVar.Map.find x env.tvar_map with
   | Not_found ->
     failwith "Internal error: unbound type variable"
+
+let in_repl_mode env = env.repl_mode

--- a/src/ToCore/Env.mli
+++ b/src/ToCore/Env.mli
@@ -9,7 +9,7 @@ open Common
 type t
 
 (** Empty environment *)
-val empty : t
+val empty : repl_mode:bool -> t
 
 (** Extend environment with type variable. *)
 val add_tvar : t -> S.tvar -> t * T.TVar.ex
@@ -26,3 +26,5 @@ val add_tvars' : t -> S.tvar list -> T.TVar.ex list -> t
 
 (** Lookup for a type variable. It must be present in the environment *)
 val lookup_tvar : t -> S.tvar -> T.TVar.ex
+
+val in_repl_mode : t -> bool

--- a/src/ToCore/Main.ml
+++ b/src/ToCore/Main.ml
@@ -151,5 +151,5 @@ and tr_expr_vs env es cont =
 
 (* ========================================================================= *)
 
-let tr_program p =
-  tr_expr Env.empty p
+let tr_program ~repl_mode p =
+  tr_expr (Env.empty ~repl_mode) p

--- a/src/ToCore/Main.mli
+++ b/src/ToCore/Main.mli
@@ -5,4 +5,4 @@
 (** Main module of a translation from Unif to Core *)
 
 (** Translate program *)
-val tr_program : Lang.Unif.program -> Lang.Core.program
+val tr_program : repl_mode:bool -> Lang.Unif.program -> Lang.Core.program

--- a/src/ToCore/Type.ml
+++ b/src/ToCore/Type.ml
@@ -32,8 +32,10 @@ let pack_type (type k) (k : S.kind) (tp : k T.typ) : T.Type.ex =
 let rec tr_effrow_end env (eff : S.Type.effrow_end) =
   match eff with
   | EEClosed -> T.TEffPure
+  | EEUVar(_,uvar) when Env.in_repl_mode env ->
+    let uid = Lang.Unif.UVar.uid uvar in
+    TUVar(uid, KEffect)
   | EEUVar _  ->
-    (* TODO: they can be supported, and its especially useful in REPL *)
     InterpLib.Error.report ~cls:FatalError
       "Unsolved unification variables left.";
     raise InterpLib.Error.Fatal_error
@@ -48,8 +50,11 @@ let rec tr_effrow_end env (eff : S.Type.effrow_end) =
 (** Translate type *)
 and tr_type env tp =
   match S.Type.view tp with
+  | TUVar(_,uvar) when Env.in_repl_mode env ->
+    let uid = Lang.Unif.UVar.uid uvar in
+    let (T.Kind.Ex k) = S.Type.kind tp |> tr_kind in
+    pack_type (S.Type.kind tp) (TUVar (uid, k))
   | TUVar _  ->
-    (* TODO: they can be supported, and its especially useful in REPL *)
     InterpLib.Error.report ~cls:FatalError
       "Unsolved unification variables left.";
     raise InterpLib.Error.Fatal_error


### PR DESCRIPTION
Implemented: Unification variables in REPL

- changed signatures of tr_program and some other functions to take additional argument whether program is launched as repl or not
- toCore.Env now keeps track of operational mode (repl or not)
- made check_invariant dependent on operational mode
- added new core type constructor
- added translation in toCore
- adapted uvars in core to what i think they should do
- in WellTypedInvariant wherever uvar may be seen it is reported as InternalError
- implemented every necessary function