### PR TITLE
Levels in scopes of unification variables.

### DIFF
--- a/src/Lang/Unif.mli
+++ b/src/Lang/Unif.mli
@@ -369,6 +369,12 @@ module Scope : sig
 
   (** Apply permutation to a scope *)
   val perm : TVar.Perm.t -> scope -> scope
+
+  (** Increase a level of given scope *)
+  val incr_level : scope -> scope
+
+  (** Get a level of given scope *)
+  val level : scope -> int
 end
 
 (* ========================================================================= *)
@@ -385,6 +391,9 @@ module UVar : sig
   (** Get a scope of a unification variable *)
   val scope : t -> scope
 
+  (** Get a level of an unification variable *)
+  val level : t -> int
+
   (** Set a unification variable, without checking any constraints. It returns
     expected scope of set type. The first parameter is a permutation attached
     to the unification variable. *)
@@ -393,9 +402,9 @@ module UVar : sig
   (** Promote unification variable to fresh type variable *)
   val fix : t -> tvar
 
-  (** Shrink scope of given unification variable, leaving only those variables
-    which satisfy given predicate *)
-  val filter_scope : t -> (tvar -> bool) -> unit
+  (** Shrink scope of given unification variable to given level, leaving only
+    those variables which satisfy given predicate. *)
+  val filter_scope : t -> int -> (tvar -> bool) -> unit
 
   (** Set of unification variables *)
   module Set : Set.S with type elt = t

--- a/src/Lang/UnifPriv/Scope.ml
+++ b/src/Lang/UnifPriv/Scope.ml
@@ -2,14 +2,46 @@
  * See LICENSE for details.
  *)
 
-(** Operations on scopes *)
+(** Scopes and operations on them *)
 
-let initial = TVar.Set.empty
+type t = {
+  tvar_set : TVar.Set.t;
+    (** Set of type variables allowed in this scope *)
 
-let add scope x = TVar.Set.add x scope
+  level    : int
+    (** Level of the scope, i.e., the number which indicates how many places
+      of implicit type generalization (let-definitions, generally) are
+      available in this lexical scope. *)
+}
+
+let initial =
+  { tvar_set = TVar.Set.empty;
+    level    = 0
+  }
+
+let add scope x =
+  { tvar_set = TVar.Set.add x scope.tvar_set;
+    level    = scope.level
+  }
 
 let add_named scope (_, x) = add scope x
 
-let mem scope x = TVar.Set.mem x scope
+let filter lvl f scope =
+  { tvar_set = TVar.Set.filter f scope.tvar_set;
+    level    = min lvl scope.level
+  }
 
-let perm p scope = TVar.Set.map (TVar.Perm.apply p) scope
+let mem scope x = TVar.Set.mem x scope.tvar_set
+
+let perm p scope =
+  { tvar_set = TVar.Perm.map_set p scope.tvar_set;
+    level    = scope.level
+  }
+
+let shrink_perm_dom scope p =
+  TVar.Perm.shrink_dom scope.tvar_set p
+
+let incr_level scope =
+  { scope with level = scope.level + 1 }
+
+let level scope = scope.level

--- a/src/Lang/UnifPriv/Scope.mli
+++ b/src/Lang/UnifPriv/Scope.mli
@@ -1,0 +1,35 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Scopes and operations on them *)
+
+type t
+
+(** Initial empty scope *)
+val initial : t
+
+(** Extend the scope with given variable *)
+val add : t -> TVar.t -> t
+
+(** Extend the scope with a named type variable *)
+val add_named : t -> ('name * TVar.t) -> t
+
+(** Shrink given scope to given level, leaving only those type variables,
+  that satisfies given predicate. *)
+val filter : int -> (TVar.t -> bool) -> t -> t
+
+(** Check if given type variable is defined in given scope *)
+val mem : t -> TVar.t -> bool
+
+(** Permute variables in given scope *)
+val perm : TVar.Perm.t -> t -> t
+
+(** Shrink the domain of given partial permutation *)
+val shrink_perm_dom : t -> TVar.Perm.t -> TVar.Perm.t
+
+(** Increase a level of given scope *)
+val incr_level : t -> t
+
+(** Get a level of given scope *)
+val level : t -> int

--- a/src/Lang/UnifPriv/Subst.ml
+++ b/src/Lang/UnifPriv/Subst.ml
@@ -47,6 +47,7 @@ let is_empty sub =
 let in_uvar sub p u =
   let p = TVar.Perm.compose sub.perm p in
   UVar.filter_scope u
+    (UVar.level u)
     (fun x -> not (TVar.Map.mem (TVar.Perm.apply p x) sub.sub));
   p
 

--- a/src/Lang/UnifPriv/Type.ml
+++ b/src/Lang/UnifPriv/Type.ml
@@ -160,7 +160,8 @@ let shrink_var_scope ~scope x =
   else raise (Escapes_scope x)
 
 let shrink_uvar_scope ~scope p u =
-  UVar.filter_scope u (fun x -> Scope.mem scope (TVar.Perm.apply p x))
+  UVar.filter_scope u (Scope.level scope)
+    (fun x -> Scope.mem scope (TVar.Perm.apply p x))
 
 let rec shrink_effrow_end_scope ~scope ee =
   match ee with

--- a/src/Lang/UnifPriv/TypeBase.mli
+++ b/src/Lang/UnifPriv/TypeBase.mli
@@ -8,7 +8,7 @@ open KindBase
 
 type uvar
 type tvar  = TVar.t
-type scope = TVar.Set.t
+type scope = Scope.t
 
 type tname =
   | TNAnon
@@ -114,6 +114,8 @@ module UVar : sig
 
   val scope : t -> scope
 
+  val level : t -> int
+
   (** Set a unification variable, without checking any constraints. It returns
     expected scope of set type. The first parameter is a permutation attached
     to unification variable *)
@@ -121,13 +123,9 @@ module UVar : sig
 
   val fix : t -> tvar
 
-  (** Shrink scope of given unification variable to intersection of current
-    and given scope. *)
-  val shrink_scope : scope:scope -> uvar -> unit
-
-  (** Shrink scope of given unification variable, leaving only those variables
-    which satisfy given predicate *)
-  val filter_scope : uvar -> (tvar -> bool) -> unit
+  (** Shrink scope of given unification variable to given level, leaving only
+    those variables which satisfy given predicate. *)
+  val filter_scope : uvar -> int -> (tvar -> bool) -> unit
 
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t

--- a/src/TypeInference/Env.ml
+++ b/src/TypeInference/Env.ml
@@ -201,25 +201,12 @@ let lookup_method env owner name =
 let lookup_tvar_pp_info env x =
   T.TVar.Map.find_opt x env.pp_map
 
-let collect_adt_uvars (info : Module.adt_info) uvars =
-  uvars
-  |> List.fold_right T.CtorDecl.collect_uvars info.adt_ctors
-  |> T.Type.collect_uvars info.adt_type
-
-let collect_method_uvars =
-  StrMap.fold (fun _ (_, sch) -> T.Scheme.collect_uvars sch)
-
-let uvars env =
-  T.UVar.Set.empty
-  |> ModStack.collect_uvars env.mod_stack
-  |> T.TVar.Map.fold
-      (fun _ -> collect_adt_uvars)
-      env.adt_map
-  |> T.TVar.Map.fold
-      (fun _ -> collect_method_uvars)
-      env.method_map
+let incr_level env =
+  { env with scope = T.Scope.incr_level env.scope }
 
 let scope env = env.scope
+
+let level env = T.Scope.level env.scope
 
 let fresh_uvar env kind =
   T.Type.fresh_uvar ~scope:env.scope kind

--- a/src/TypeInference/Env.mli
+++ b/src/TypeInference/Env.mli
@@ -116,11 +116,15 @@ val lookup_method : t -> T.tvar -> S.method_name -> (T.var * T.scheme) option
 (** Lookup for pretty-printing information about type variable *)
 val lookup_tvar_pp_info : t -> T.tvar -> pp_info option
 
-(** Set of unification variables in the environment *)
-val uvars : t -> T.UVar.Set.t
+(** Increase the level of the environment's scope. The level should be
+  increased for each place, when implicit type generalization can occur. *)
+val incr_level : t -> t
 
 (** Get current scope *)
 val scope : t -> T.scope
+
+(** Get a level of given environment *)
+val level : t -> int
 
 (** Create a fresh unification variable in current scope *)
 val fresh_uvar : t -> T.kind -> T.typ

--- a/src/TypeInference/ExprUtils.ml
+++ b/src/TypeInference/ExprUtils.ml
@@ -52,18 +52,8 @@ let rec make_tapp e tps =
     in
     make_tapp e tps
 
-let generalize ~pos env tvs2 named e tp =
-  Uniqueness.check_generalized_named_types ~pos tvs2;
-  let tvs1 =
-    List.fold_left
-      (fun tvs (_, _, isch) -> T.Scheme.collect_uvars isch tvs)
-      (T.Type.uvars tp)
-      named
-    |> Fun.flip T.UVar.Set.diff (Env.uvars env)
-    |> T.UVar.Set.elements
-    |> List.map (fun x -> (T.TNAnon, T.UVar.fix x))
-  in
-  let tvs = tvs1 @ tvs2 in
+let generalize ~pos tvs named e tp =
+  Uniqueness.check_generalized_named_types ~pos tvs;
   let sch =
     { T.sch_targs = tvs
     ; T.sch_named = List.map (fun (name, _, sch) -> (name, sch)) named

--- a/src/TypeInference/ExprUtils.mli
+++ b/src/TypeInference/ExprUtils.mli
@@ -15,12 +15,13 @@ val make_nfun : (T.name * T.var * T.scheme) list -> T.expr -> T.expr
 (** Generate a type application to given list of types *)
 val make_tapp : T.expr -> T.typ list -> T.expr
 
-(** Generalize type to polymorphic scheme. The second parameter is a list
-  of explicit type parameters, and the third parameter is a list of
+(** Generalize type to polymorphic scheme. The first parameter is a list
+  of type parameters (explicit or implicitly introduced by
+  [ImplicitEnv.end_generalize_pure], and the second parameter is a list of
   implicit parameters. *)
 val generalize :
   pos:Position.t ->
-  Env.t -> T.named_tvar list -> (T.name * T.var * T.scheme) list ->
+  T.named_tvar list -> (T.name * T.var * T.scheme) list ->
   T.expr -> T.typ -> T.expr * T.scheme
 
 (** Guess types used to instantiate polymorphic function. Some of these types

--- a/src/TypeInference/ImplicitEnv.mli
+++ b/src/TypeInference/ImplicitEnv.mli
@@ -16,17 +16,24 @@ type implicit_list
 (** Empty environment *)
 val empty : t
 
-(** Prepare environment to generalizing implicit parameters: it add implicit
-  parameters to the environment. *)
+(** Prepare environment to generalizing implicit parameters: it adds implicit
+  parameters to the environment and increases the level of the environment. *)
 val begin_generalize : Env.t -> t -> Env.t * implicit_list
 
-(** Get a list of types and implicits, that were used, and therefore, should
-  be generalized. *)
-val end_generalize_pure : implicit_list ->
+(** Build a list of types and implicit parameters that should be implicitly
+  generalized. The second parameter is a set of unification variables that
+  appears in the type/scheme of generalized entity. This function tries to
+  generalize only those implicits that were used. *)
+val end_generalize_pure :
+  implicit_list -> T.UVar.Set.t ->
   T.named_tvar list * (T.name * T.var * T.scheme) list
 
-(** Ensure, that no implicits on a given list were used. *)
-val end_generalize_impure : implicit_list -> unit
+(** Ensure, that no implicits on a given list were used and the given type
+  fits in the scope of [begin_generalize] that created the implicit list.
+  The position and environment are used to report escaping type variables,
+  so the environment should be as wide as the given type. *)
+val end_generalize_impure :
+  pos:Position.t -> env:Env.t -> implicit_list -> T.typ -> unit
 
 (** Extend environment with a declaration of implicit *)
 val declare_implicit : t -> S.iname -> T.named_tvar list -> T.scheme -> t

--- a/src/TypeInference/ModStack.ml
+++ b/src/TypeInference/ModStack.ml
@@ -59,8 +59,6 @@ let lookup_tvar stack = lookup_path stack Module.lookup_tvar
 
 let lookup_module stack = lookup_path stack Module.lookup_module
 
-let collect_uvars = fold_right Module.collect_uvars
-
 let enter_module (m, stack) = (Module.empty, m :: stack)
 
 let leave_module (old_top, stack) ~public name =

--- a/src/TypeInference/ModStack.mli
+++ b/src/TypeInference/ModStack.mli
@@ -49,10 +49,6 @@ val lookup_tvar : t -> S.tvar S.path -> T.typ option
 (** Lookup for a module of the given name. *)
 val lookup_module : t -> S.module_name S.path -> Module.t option
 
-(** Extend the given set of unification variables by unification variables
-  found in the module stack. *)
-val collect_uvars : t -> T.UVar.Set.t -> T.UVar.Set.t
-
 (** Create a new module on top of the module stack *)
 val enter_module : t -> t
 

--- a/src/TypeInference/Module.ml
+++ b/src/TypeInference/Module.ml
@@ -131,21 +131,6 @@ let rec lookup_path m lookup (p : 'a S.path) =
   | NPSel(x, p) ->
     Option.bind (lookup_module m x) (fun m -> lookup_path m lookup p)
 
-let rec collect_uvars m uvars =
-  uvars
-  |> StrMap.fold
-      (fun _ { data = (_, sch); _ } -> T.Scheme.collect_uvars sch)
-      m.var_map
-  |> StrMap.fold
-      (fun _ { data = tp; _ } -> T.Type.collect_uvars tp)
-      m.tvar_map
-  |> StrMap.fold
-      (fun _ { data = (_, sch, _); _ } -> T.Scheme.collect_uvars sch)
-      m.implicit_map
-  |> StrMap.fold
-      (fun _ { data = ns; _ } -> collect_uvars ns)
-      m.mod_map
-
 let filter_public m =
   let public _ info = info.public in
   { var_map      = StrMap.filter public m.var_map;

--- a/src/TypeInference/Module.mli
+++ b/src/TypeInference/Module.mli
@@ -78,10 +78,6 @@ val lookup_module : t -> S.module_name -> t option
   Returns [None] if the path is invalid or the lookup fails. *)
 val lookup_path : t -> (t -> 'a -> 'b option) -> 'a S.path -> 'b option
 
-(** Extend the given set of unification variables by unification variables
-  found in the module stack. *)
-val collect_uvars : t -> T.UVar.Set.t -> T.UVar.Set.t
-
 (** Remove all private definitions from the module. *)
 val filter_public : t -> t
 

--- a/src/TypeInference/Unification.ml
+++ b/src/TypeInference/Unification.ml
@@ -109,7 +109,7 @@ let rec check_subeffect env eff1 eff2 =
     else
       begin match T.Effect.view_end eff2 with
       | EEUVar(p2, u2) when T.UVar.equal u1 u2 ->
-        T.UVar.filter_scope u1 (T.TVar.Perm.agree_on p1 p2)
+        T.UVar.filter_scope u1 (T.UVar.level u2) (T.TVar.Perm.agree_on p1 p2)
       | _ ->
         (** TODO: add constraint, instead of such combinations *)
         let scope = T.Scope.perm p1 (T.UVar.scope u1) in
@@ -161,7 +161,7 @@ and unify env tp1 tp2 =
     assert false
 
   | TUVar(p1, u1), TUVar(p2, u2) when T.UVar.equal u1 u2 ->
-    T.UVar.filter_scope u1 (T.TVar.Perm.agree_on p1 p2)
+    T.UVar.filter_scope u1 (T.UVar.level u2) (T.TVar.Perm.agree_on p1 p2)
   | TUVar(p, u), _ ->
     if T.Type.contains_uvar u tp2 then
       raise Error
@@ -237,7 +237,7 @@ let rec check_subtype env tp1 tp2 =
     failwith "Internal kind error"
 
   | TUVar(p1, u1), TUVar(p2, u2) when T.UVar.equal u1 u2 ->
-    T.UVar.filter_scope u1 (T.TVar.Perm.agree_on p1 p2)
+    T.UVar.filter_scope u1 (T.UVar.level u2) (T.TVar.Perm.agree_on p1 p2)
   | TUVar(p, u), _ ->
     if T.Type.contains_uvar u tp2 then
       raise Error

--- a/test/ok/ok0085_letChecked.dbl
+++ b/test/ok/ok0085_letChecked.dbl
@@ -1,0 +1,6 @@
+let f x =
+  let y =
+    match x with
+    | _ => x
+    end
+  in y

--- a/test/ok/ok0086_optionState.dbl
+++ b/test/ok/ok0086_optionState.dbl
@@ -1,0 +1,32 @@
+data Option A = None | Some of A
+
+data State (effect E) X = State of
+  { get    : Unit ->[E] X
+  , put    : X ->[E] Unit
+  }
+
+implicit `st {E_st} : State E_st _
+
+let get x =
+  let (State { get }) = `st in
+  get x
+
+let put x =
+  let (State { put }) = `st in
+  put x
+
+handle `st =
+  let get = effect x / r => fn s => r s  s
+  let put = effect s / r => fn _ => r () s
+  in State { get, put }
+  return  x => fn _ => x
+  finally c => c None
+
+let putSome f =
+  put (Some f)
+
+let _ =
+  match get () with
+  | None   => ()
+  | Some f => f ()
+  end


### PR DESCRIPTION
I've modified implementation of ML-polymorphism to use levels of unification variables in order to get rid of costly environment traversing. It turns out that in our case (binders in types, permutations) using levels for tracking escaping variables seems to be a challenging task and is not implemented: escaping variables are tracked as before, using sets of type variables. Introduced changes are summarized below.

- Now, the scope of unification variable contains its level
- Costly traversing environments and modules for searching unification variables is removed, as it is sufficient to select unification variables with high enough level for generalization.
- Environment remember its level. The level of the environment is maintained by `ImplicitEnv.begin_generalize` and `ImplicitEnv.end_generalize_*` functions.
- All the functionality regarding generalization of implicits and unification variables is moved to the `ImplicitEnv` module. The `ExprUtils.generalize` only builds necessary lambda-abstractions, but do not select any types to generalize.
- Generalization of type variables is unified between let-definitions and type annotations in implicit declarations.

This pull-request should resolve #24 