### PR TITLE
Added declaration of method functions

### DIFF
--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -159,9 +159,6 @@ and poly_expr_data =
   | EImplicit of iname path
     (** Implicit parameter *)
 
-  | ECtor     of ctor_name path
-    (** ADT constructor *)
-
   | EMethod   of expr * method_name
     (** Call of a method *)
 
@@ -224,6 +221,9 @@ and def_data =
 
   | DLetPat  of pattern * expr
     (** Let definition combined with pattern-matching. Always monomorphic *)
+
+  | DMethodFn of var * method_name
+    (** Declaration of function that should be interpreted as a method *)
 
   | DLabel   of type_arg option * pattern
     (** Creating a new label. Optional type argument binds newly created

--- a/src/Parser/Raw.ml
+++ b/src/Parser/Raw.ml
@@ -16,6 +16,15 @@ type var = string
 (** Names of implicit parameters *)
 type iname = string
 
+(** Names of operators *)
+type op_name = string
+
+(** Variable-like identifier *)
+type var_id =
+  | VIdVar of var
+  | VIdBOp of op_name
+  | VIdUOp of op_name
+
 (** Name of a named parameter *)
 type name = Lang.Surface.name =
   | NLabel
@@ -30,9 +39,6 @@ type method_name = string
 
 (** Names of modules *)
 type module_name = string
-
-(** Names of operators *)
-type op_name = string 
 
 (** Module path to an identifier of type 'a *)
 type 'a path = 'a Lang.Surface.path =
@@ -220,6 +226,9 @@ and def_data =
 
   | DMethod of expr * expr
     (** Method definition *)
+
+  | DMethodFn of var_id * var_id
+    (** Declaration of function that should be interpreted as a method *)
 
   | DModule of module_name * def list
     (** Definition of a module *)

--- a/src/Parser/YaccParser.mly
+++ b/src/Parser/YaccParser.mly
@@ -49,6 +49,12 @@ bar_opt
 
 /* ========================================================================= */
 
+var_id
+: LID                  { VIdVar $1 }
+| BR_OPN op BR_CLS     { VIdBOp ($2).data }
+| BR_OPN op DOT BR_CLS { VIdUOp ($2).data }
+;
+
 name
 : KW_LABEL { NLabel       }
 | LID      { NVar $1      }
@@ -454,8 +460,10 @@ def
 ;
 
 def_10
-: data_def               { make (DData $1)     }
-| KW_LET expr_70 EQ expr    { make (DLet($2, $4)) }
+: KW_LET expr_70 EQ expr { make (DLet($2, $4)) }
+| KW_METHOD KW_FN var_id { make (DMethodFn($3, $3)) }
+| KW_METHOD KW_FN var_id EQ var_id { make (DMethodFn($3, $5)) }
+| data_def               { make (DData $1)     }
 | data_rec data_rec_rest { make (DDataRec ($1 :: $2)) }
 | KW_LABEL  expr         { make (DLabel $2) }
 | KW_HANDLE expr_70 EQ expr h_clauses      { make (DHandle($2, $4, $5)) }

--- a/src/TypeInference/Env.ml
+++ b/src/TypeInference/Env.ml
@@ -71,6 +71,9 @@ let add_mono_implicit ?(public=false) env name tp on_use =
 let add_the_label env eff tp0 eff0 =
   add_mono_var env "#label" (T.Type.t_label eff tp0 eff0)
 
+let add_method_fn ~public env x name =
+  { env with mod_stack = ModStack.add_method_fn ~public env.mod_stack x name }
+
 let add_tvar ?pos ?(public=false) env name kind =
   let mod_stack, x = ModStack.add_tvar ~public env.mod_stack name kind in
   let pp_info = 
@@ -179,9 +182,11 @@ let scheme_to_label sch =
 let lookup_the_label env =
   match lookup_var env (NPName "#label") with
   | None -> None
-  | Some(x, sch) ->
+  | Some(VI_Var (x, sch)) ->
     let (eff, tp0, eff0) = scheme_to_label sch in
     Some(x, eff, tp0, eff0)
+  | Some(VI_Ctor _ | VI_MethodFn _) ->
+    assert false
 
 let lookup_ctor env =
   ModStack.lookup_ctor env.mod_stack

--- a/src/TypeInference/Env.mli
+++ b/src/TypeInference/Env.mli
@@ -44,6 +44,10 @@ val add_mono_implicit :
   be passed as a parameters. *)
 val add_the_label : t -> T.effect -> T.typ -> T.effrow -> t * T.var
 
+(** Extend an environment with information that given identifier when used
+  as function is a method of given name. *)
+val add_method_fn : public:bool -> t -> S.var -> S.method_name -> t
+
 (** Extend an environment with a named type variable. The optional position
   should point to the place of binding in the source code. *)
 val add_tvar :
@@ -78,9 +82,9 @@ val add_ctor : ?public:bool -> t -> string -> int -> Module.adt_info -> t
   as the owner *)
 val add_poly_method : t -> T.tvar -> S.method_name -> T.scheme -> t * T.var
 
-(** Lookup for Unif representation and a scheme of a variable. Returns [None]
-  if variable is not bound. *)
-val lookup_var : t -> S.var S.path -> (T.var * T.scheme) option
+(** Lookup for variable-like identifier. Returns [None] if variable is not
+  bound. *)
+val lookup_var : t -> S.var S.path -> Module.var_info option
 
 (** Lookup for Unif representation, a scheme, and "on-use" function of a named
   implicit. Returns [None] if implicit is not bound. *)

--- a/src/TypeInference/Error.ml
+++ b/src/TypeInference/Error.ml
@@ -94,6 +94,11 @@ let unbound_method ~pos ~env x name =
     name
   in (pos, msg ^ Pretty.additional_info pp_ctx, [])
 
+let method_fn_without_arg ~pos x name =
+  (pos, Printf.sprintf
+    "Variable %s is registered as method %s and cannot be used without argument"
+    (string_of_path x) name, [])
+
 let expr_type_mismatch ~pos ~env tp1 tp2 =
   let pp_ctx = Pretty.empty_context () in
   let msg = Printf.sprintf

--- a/src/TypeInference/Error.mli
+++ b/src/TypeInference/Error.mli
@@ -38,6 +38,9 @@ val unbound_the_label : pos:Position.t -> t
 val unbound_method :
   pos:Position.t -> env:Env.t -> T.tvar -> S.method_name -> t
 
+val method_fn_without_arg :
+  pos:Position.t -> S.var S.path -> S.method_name -> t
+
 val expr_type_mismatch   : pos:Position.t -> env:Env.t -> T.typ -> T.typ -> t
 val expr_effect_mismatch :
   pos:Position.t -> env:Env.t -> T.effrow -> T.effrow -> t

--- a/src/TypeInference/ModStack.ml
+++ b/src/TypeInference/ModStack.ml
@@ -24,6 +24,9 @@ let add_var (m, stack) ~public x sch =
   let m, y = Module.add_var m ~public x sch in
   (m, stack), y
 
+let add_method_fn (m, stack) ~public x name =
+  (Module.add_method_fn m ~public x name, stack)
+
 let add_tvar (m, stack) ~public name kind =
   let m, x = Module.add_tvar m ~public name kind in
   (m, stack), x

--- a/src/TypeInference/ModStack.mli
+++ b/src/TypeInference/ModStack.mli
@@ -14,6 +14,10 @@ val toplevel : t
 (** Extend the current module with a polymorphic variable *)
 val add_var : t -> public:bool -> S.var -> T.scheme -> t * T.var
 
+(** Extend the current module with information that given identifier when used
+  as function is a method of given name. *)
+val add_method_fn : t -> public:bool -> S.var -> S.method_name -> t
+
 (** Extend the current module with a named type variable. *)
 val add_tvar : t -> public:bool -> S.tvar -> T.kind -> t * T.tvar
 
@@ -28,9 +32,9 @@ val add_implicit :
 (** Add constructor of given name and index to the current module. *)
 val add_ctor : t -> public:bool -> string -> int -> Module.adt_info -> t
 
-(** Lookup for Unif representation and a scheme of a variable. Returns [None]
-  if variable is not bound. *)
-val lookup_var : t -> S.var S.path -> (T.var * T.scheme) option
+(** Lookup for variable-like identifier. Returns [None] if variable is not
+  bound. *)
+val lookup_var : t -> S.var S.path -> Module.var_info option
 
 (** Lookup for Unif representation, a scheme, and "on-use" function of a named
   implicit. Returns [None] if implicit is not bound. *)

--- a/src/TypeInference/Module.mli
+++ b/src/TypeInference/Module.mli
@@ -24,6 +24,17 @@ type adt_info = {
     (** The type that is an ADT, already applied to [adt_args] *)
 }
 
+(** Information about variable-like identifier (variable, constructor, etc.) *)
+type var_info =
+  | VI_Var  of T.var * T.scheme
+    (** Variable: its Unif representation and its type scheme *)
+
+  | VI_Ctor of int * adt_info
+    (** Constructor: its index and full information about ADT *)
+
+  | VI_MethodFn of S.method_name
+    (** Function that is automatically translated to method call *)
+
 (** The built-in unit type *)
 val unit_info : adt_info
 
@@ -35,6 +46,10 @@ val toplevel : t
 
 (** Extend the module with a polymorphic variable *)
 val add_var : t -> public:bool -> S.var -> T.scheme -> t * T.var
+
+(** Extend the module with information that given identifier when used
+  as function is a method of given name. *)
+val add_method_fn : t -> public:bool -> S.var -> S.method_name -> t
 
 (** Extend the module with a named type variable. *)
 val add_tvar : t -> public:bool -> S.tvar -> T.kind -> t * T.tvar
@@ -53,9 +68,9 @@ val add_ctor : t -> public:bool -> string -> int -> adt_info -> t
 (** Extend the module with the definition of a module with the given name. *)
 val add_module : t -> public:bool -> S.module_name -> t -> t
 
-(** Lookup for Unif representation and a scheme of a variable. Returns [None]
-  if variable is not bound. *)
-val lookup_var : t -> S.var -> (T.var * T.scheme) option
+(** Lookup for variable-like identifier. Returns [None] if variable is not
+  bound. *)
+val lookup_var : t -> S.var -> var_info option
 
 (** Lookup for Unif representation, a scheme, and "on-use" function of a named
   implicit. Returns [None] if implicit is not bound. *)

--- a/test/err/tc_0004_methodFn.dbl
+++ b/test/err/tc_0004_methodFn.dbl
@@ -1,0 +1,2 @@
+method fn x
+let _ = x

--- a/test/ok/ok0087_opratorOverloading.dbl
+++ b/test/ok/ok0087_opratorOverloading.dbl
@@ -1,0 +1,7 @@
+method add = (extern dbl_addInt : Int -> Int -> Int) self
+method add = (extern dbl_strCat : String -> String -> String) self
+
+method fn (+) = add
+
+let _ = 2 + 2
+let _ = "a" + "b"


### PR DESCRIPTION
The motivation was to enable operator overloading via declaration as `method fn (+) = add` which is simpler to type-check and more flexible than the approach based on higher order methods. The changes are the following.

- Added `method fn x = name` construct.
- Added `method fn x` construct as a syntactic sugar for `method fn x = x`.
- Added `var_info` type to `TypeInference.Module` that stores a class of identifier (regular variable / constructor / method function).
- Removed `ECtor` constructor from `Surface`: constructors (as expressions) are variables, but their `var_info` contains all information about ADT. The `ctor_map` field of `TypeInference.Module.t` is still needed for type-checking of patterns.

These changes should also pave the path towards allowing operators to be ADT constructors.