### PR TITLE
Infix constructors and syntactic sugar for lists

### DIFF
--- a/examples/LWT.dbl
+++ b/examples/LWT.dbl
@@ -36,7 +36,7 @@ handle {effect=Sched} (`st : State Sched (List (Thread [Sched,IO]))) =
   let update f = put (f (get ())) in
     State { get, put, update }
   return  x => fn _ => x
-  finally c => c Nil
+  finally c => c []
 
 (* The global label of an LWT effect. *)
 label {effect=LWT} lwt_lbl
@@ -56,13 +56,13 @@ method spawn {self = LWT {spawn}} = spawn
 (* Run the scheduler: just pick the next thread from the queue *)
 let sched () =
   match get () with
-  | Nil                 => ()
-  | Cons (Thread thr) q => let _ = put q in thr ()
+  | []              => ()
+  | Thread thr :: q => let _ = put q in thr ()
   end
 
 (* Put a thread to the scheduler queue *)
 let enqueue thr =
-  update (fn q => append q (Cons (Thread thr) Nil))
+  update (fn q => append q [Thread thr])
 
 (* Here, we handle LWT effect. Note that the handler does not provide any
   capability. It only plays a role of the delimiter (reset0) on given label.

--- a/examples/LWT_lexical.dbl
+++ b/examples/LWT_lexical.dbl
@@ -52,19 +52,19 @@ handle {effect=Sched} `st =
   let update f = put (f (get ())) in
     State { get, put, update }
   return  x => fn _ => x
-  finally c => c Nil
+  finally c => c []
 
 (* Enqueue a ready thread to the scheduler queue. Note that thanks to the
   mechanism of implicit parameters, this function uses `st capability, without
   mentioning it explicitly. *)
 let enqueue thr =
-  update (fn queue => append queue (Cons thr Nil))
+  update (fn queue => append queue [thr])
 
 (* Run the scheduler. It picks one thread from the queue and runs it. *)
 let sched _ =
   match get () with
-  | Nil           => ()
-  | Cons thr thrs =>
+  | []          => ()
+  | thr :: thrs =>
     let _ = put thrs in
     thr ()
   end

--- a/examples/Prolog.dbl
+++ b/examples/Prolog.dbl
@@ -41,8 +41,8 @@ method fail {E, self = BT { fail } : BT E} = fail
   library. *)
 method choose {E, self : BT E} = fix (fn choose xs =>
   match xs with
-  | Nil       => self.fail ()
-  | Cons x xs => if self.flip () then x else choose xs
+  | []      => self.fail ()
+  | x :: xs => if self.flip () then x else choose xs
   end)
 
 (* The `Fresh` effect is used to model the generation of fresh variable
@@ -82,8 +82,8 @@ let hBT (f : {effect=E} -> BT E ->[E|_] _) =
 
 let exists f = fix (fn exists xs =>
   match xs with
-  | Nil       => False
-  | Cons x xs => f x && exists xs
+  | []      => False
+  | x :: xs => f x && exists xs
   end)
 
 (* The following few functions on lists require a notion of equality, which is
@@ -93,8 +93,8 @@ implicit `eq
 
 let nub = fix (fn nub xs =>
   match xs with
-  | Nil       => Nil
-  | Cons x xs => Cons x (nub (filter (fn y => not (`eq x y)) xs))
+  | []      => []
+  | x :: xs => x :: nub (filter (fn y => not (`eq x y)) xs)
   end)
 
 let union xs ys = nub (append xs ys)
@@ -102,8 +102,8 @@ let unions xss = nub (concat xss)
 
 let assoc x = fix (fn assoc xs =>
   match xs with
-  | Nil                => None
-  | Cons (Pair y v) xs => if `eq x y then Some v else assoc xs
+  | []           => None
+  | (y, v) :: xs => if `eq x y then Some v else assoc xs
   end)
 
 (* ========================================================================= *)
@@ -114,7 +114,7 @@ method vars =
   let `eq (x : Int) = x.equal in
   fix (fn vars t =>
   match t with
-  | TVar x    => Cons x Nil
+  | TVar x    => [x]
   | TFun _ ts => unions (map vars ts)
   end) self
 
@@ -147,7 +147,7 @@ implicit `st {E_st} : State E_st (List (Pair Int Term))
 
 (* We also define a pair of functions that let us modify and read `st. *)
 
-let setVar (x : Int) t = `st.update (fn xs => Cons (Pair x t) xs)
+let setVar (x : Int) t = `st.update (fn xs => (x, t) :: xs)
 
 let getVar x =
   let `eq (x : Int) = x.equal in
@@ -182,10 +182,10 @@ let fresh () = `fresh.fresh ()
   all the variables in terms with fresh unification variables. *)
 
 method refresh {self : Term} =
-  self.rename (map (fn x => Pair x (fresh ())) self.vars)
+  self.rename (map (fn x => (x, fresh ())) self.vars)
 
 method refresh {self : Clause} =
-  self.rename (map (fn x => Pair x (fresh ())) self.vars)
+  self.rename (map (fn x => (x, fresh ())) self.vars)
 
 (* ========================================================================= *)
 
@@ -206,14 +206,14 @@ method occurs (x : Int) = fix (fn occurs (t : Term) =>
 
 (* Attempt to unify two terms, and signal the need to backtrack on failure. *)
 let unify = fix (fn unify (t1 : Term) (t2 : Term) =>
-  match Pair t1.view t2.view with
-  | Pair (TVar x) (TVar y) =>
+  match t1.view, t2.view with
+  | TVar x, TVar y =>
     if x == y then () else setVar x (TVar y)
-  | Pair (TVar x) t =>
+  | TVar x, t =>
     if t.occurs x then fail () else setVar x t
-  | Pair t (TVar x) =>
+  | t, TVar x =>
     if t.occurs x then fail () else setVar x t
-  | Pair (TFun f ts1) (TFun g ts2) =>
+  | TFun f ts1, TFun g ts2 =>
     if f == g then iter2 {`re = fail} unify ts1 ts2
     else fail ()
   end)
@@ -236,7 +236,7 @@ let query (t : Term) = eval t.refresh
   use on a simple hardcoded query. *)
 
 (* Example database. *)
-let kb = Cons (Cl (TFun "f" (Cons (TVar 0) (Cons (TVar 0) Nil))) Nil) Nil
+let kb = [Cl (TFun "f" [TVar 0, TVar 0]) []]
 
 handle `kb = Reader (fn () => kb)
 
@@ -247,9 +247,9 @@ handle `fresh = Fresh (effect _ / r => fn v => r v (1 + v))
 let _ =
   match
     hBT (fn `bt =>
-    hState Nil (fn `st =>
+    hState [] (fn `st =>
 	(* Example query. *)
-    query (TFun "f" (Cons (TFun "a" Nil) (Cons (TFun "a" Nil) Nil)))))
+    query (TFun "f" [TFun "a" [], TFun "a" []])))
   with
   | Some _ => printStrLn "Yes."
   | None   => printStrLn "No."

--- a/examples/Pythagorean.dbl
+++ b/examples/Pythagorean.dbl
@@ -45,11 +45,11 @@ let takeFirst (f : {effect=E} -> BT E -> Int ->[E|_] _) (n: Int) =
 
 (* The function `takeAll` returns list of all triples found. *)
 let takeAll (f : {effect=E} -> BT E -> Int ->[E|_] _) (n: Int) =
-  handle bt = BT { flip = effect () / r =>
-    append (r True) (r False)
-  , fail = effect () => Nil
-  }
-  return x => Cons x Nil
+  handle bt = BT
+    { flip = effect () / r => append (r True) (r False)
+    , fail = effect () => []
+    }
+  return x => [x]
   in f bt n
 
 (* Printing utilities *)
@@ -59,10 +59,11 @@ let printTriple t =
     "(" + a.toString + " " + b.toString + " " + c.toString + ")")
   end
 
-let printList = fix (fn printList xs => match xs with
-| Nil => printStrLn ""
-  | Cons t xs => let _ = printTriple t in
-                         printList xs
+let printList = fix (fn printList xs =>
+  match xs with
+  | [] => printStrLn ""
+  | t :: xs => let _ = printTriple t in
+                       printList xs
   end)
 
 (* Main program *)

--- a/examples/Tick.dbl
+++ b/examples/Tick.dbl
@@ -34,4 +34,6 @@ let length xs = count (flip map xs) id
 
 (* This code should print 2. *)
 let _ =
-  printStrLn (length (Cons () (Cons () Nil))).toString
+  printStrLn (length [13,42]).toString
+
+// @stdout:2

--- a/lib/Prelude.dbl
+++ b/lib/Prelude.dbl
@@ -4,16 +4,16 @@ data Option A = None | Some of A
 
 data rec Nat = Zero | Succ of Nat
 
-data rec List A = Nil | Cons of A, List A
+data rec List A = [] | (::) of A, List A
 
-data Pair X Y = Pair of X, Y
+data Pair X Y = (,) of X, Y
 
 let id x = x
 
 let flip f x y = f y x
 
-let fst (Pair x _) = x
-let snd (Pair _ y) = y
+let fst (x, _) = x
+let snd (_, y) = y
 
 let fix {type A, type B, type E} f =
   data rec Fix = Fix of (Fix -> A ->[|E] B)
@@ -22,47 +22,40 @@ let fix {type A, type B, type E} f =
 
 let map f = fix (fn map xs =>
   match xs with
-  | Nil       => Nil
-  | Cons x xs => Cons (f x) (map xs)
+  | []      => []
+  | x :: xs => f x :: map xs
   end)
 
 let filter f = fix (fn filter xs =>
   match xs with
-  | Nil       => Nil
-  | Cons x xs => if f x then Cons x (filter xs) else filter xs
+  | []      => []
+  | x :: xs => if f x then x :: filter xs else filter xs
   end)
 
 let append xs ys = fix (fn append xs =>
   match xs with
-  | Nil       => ys
-  | Cons x xs => Cons x (append xs)
+  | []      => ys
+  | x :: xs => x :: append xs
   end) xs
 
 let concat = fix (fn concat xss =>
   match xss with
-  | Nil         => Nil
-  | Cons xs xss => append xs (concat xss)
+  | []        => []
+  | xs :: xss => append xs (concat xss)
   end)
 
 let iter f = fix (fn iter xs =>
   match xs with
-  | Nil       => ()
-  | Cons x xs => let _ = f x in iter xs
+  | []      => ()
+  | x :: xs => let () = f x in iter xs
   end)
 
 let iter2 {`re : {type X} -> Unit ->[|_] X} f =
   fix (fn iter xs ys =>
-  match xs with
-  | Nil       =>
-    match ys with
-    | Nil       => ()
-    | Cons _ _  => `re ()
-    end
-  | Cons x xs =>
-    match ys with
-    | Nil       => `re ()
-    | Cons y ys => let _ = f x y in iter xs ys
-    end
+  match xs, ys with
+  | [],      []      => ()
+  | x :: xs, y :: ys => let () = f x y in iter xs ys
+  | _                => `re ()
   end)
 
 let not b = if b then False else True

--- a/src/Parser/Desugar.ml
+++ b/src/Parser/Desugar.ml
@@ -26,6 +26,14 @@ let tr_var_id (var : Raw.var_id) =
   | VIdBOp op -> make_bop_id op
   | VIdUOp op -> make_uop_id op
 
+let tr_ctor_name (cname : Raw.ctor_name) =
+  match cname with
+  | CNUnit   -> "()"
+  | CNNil    -> "[]"
+  | CNId  c  -> c
+  | CNBOp op -> make_bop_id op
+  | CNUOp op -> make_uop_id op
+
 type ty_def =
   | TD_Id of tvar * Raw.type_expr list
     (** Name with parameters *)
@@ -213,10 +221,12 @@ let tr_ctor_decl ~public:cd_public (d : Raw.ctor_decl) =
   let make data = { d with data = data } in
   match d.data with
   | CtorDecl(cd_name, { data = TRecord flds; _ } :: schs ) ->
+    let cd_name = tr_ctor_name cd_name in
     let (cd_targs, cd_named) = map_inst_like tr_scheme_field flds in
     let cd_arg_schemes = List.map tr_scheme_expr schs in
     make { cd_public; cd_name; cd_targs; cd_named; cd_arg_schemes }
   | CtorDecl(cd_name, schs) ->
+    let cd_name = tr_ctor_name cd_name in
     let cd_arg_schemes = List.map tr_scheme_expr schs in
     make { cd_public; cd_name; cd_targs = []; cd_named = []; cd_arg_schemes }
 
@@ -253,14 +263,17 @@ let rec collect_fields ~ppos (es : Raw.expr list) =
 (** Translate a constructor name in a pattern *)
 let rec tr_ctor_pattern (p : Raw.expr) =
   match p.data with
-  | EUnit            -> NPName "()"
+  | EUnit            -> NPName (tr_ctor_name CNUnit)
   | ECtor c          -> NPName c
   | EBOpID name      -> NPName (make_bop_id name)
   | EUOpID name      -> NPName (make_uop_id name)
+  | EList []         -> NPName (tr_ctor_name CNUnit)
   | ESelect(path, p) -> path_append path (tr_ctor_pattern p)
+
   | EWildcard | ENum _ | EStr _ | EParen _ | EVar _ | EImplicit _
   | EFn _ | EApp _ | EDefs _ | EMatch _ | EHandler _ | EEffect _ | ERecord _
-  | EMethod _ | EExtern _ | EAnnot _ | EIf _ | EBOp _ | EUOp _ | EPub _ ->
+  | EMethod _ | EExtern _ | EAnnot _ | EIf _ | EBOp _ | EUOp _ | EList (_ :: _)
+  | EPub _ ->
     Error.fatal (Error.desugar_error p.pos)
 
 (** Translate a pattern *)
@@ -289,6 +302,15 @@ let rec tr_pattern ~public (p : Raw.expr) =
   | EUOp(op, p1) ->
     let c_name = {op with data = NPName (make_uop_id op.data)} in
     make (PCtor(c_name, [], [], [tr_pattern ~public p1]))
+  | EList ps ->
+    let cons pe xs =
+      let pe  = tr_pattern ~public pe in
+      let pos = Position.join pe.pos p.pos in
+      let cpath = make (NPName (tr_ctor_name (CNBOp "::"))) in
+      { pos; data = PCtor(cpath, [], [], [pe; xs]) }
+    in
+    let pnil = make (PCtor(make (NPName (tr_ctor_name CNNil)), [], [], [])) in
+    make (List.fold_right cons ps pnil).data
   | EPub p -> make (tr_pattern ~public:true p).data
 
   | EFn _ | EDefs _ | EMatch _ | EHandler _ | EEffect _ | ERecord _
@@ -324,7 +346,7 @@ let rec tr_function_arg (arg : Raw.expr) =
   | EAnnot(p, sch) ->
     ArgAnnot(tr_pattern ~public:false p, tr_scheme_expr sch)
   | EWildcard | EUnit | ENum _ | EStr _ | EVar _ | EImplicit _ | ECtor _
-  | EBOp _ | EUOp _ | EApp _ | EBOpID _ | EUOpID _  | ESelect _ ->
+  | EBOp _ | EUOp _ | EApp _ | EBOpID _ | EUOpID _  | ESelect _ | EList _ ->
     ArgPattern (tr_pattern ~public:false arg)
 
   | EFn _ | EEffect _ | EDefs _ | EMatch _ | EHandler _ | ERecord _
@@ -374,7 +396,7 @@ let rec tr_let_pattern ~public (p : Raw.expr) =
       let (targs, iargs) = map_inst_like tr_named_arg flds in
       LP_Fun(id, targs, iargs, ps)
 
-    | EUnit | ENum _ | EStr _ | ECtor _ | ESelect _ ->
+    | EUnit | ENum _ | EStr _ | ECtor _ | ESelect _ | EList _ ->
       LP_Pat(tr_pattern ~public p)
 
     | EWildcard | EParen _ | EFn _ | EApp _ | EDefs _ 
@@ -384,7 +406,7 @@ let rec tr_let_pattern ~public (p : Raw.expr) =
     end
 
   | EWildcard | EUnit | ENum _ | EStr _ | EParen _ | ECtor _ | EAnnot _
-  | EBOp _  | EUOp _  | ESelect _ | EPub _ ->
+  | EBOp _  | EUOp _  | ESelect _ | EList _ | EPub _ ->
     LP_Pat (tr_pattern ~public p)
 
   | EFn _ | EDefs _ | EMatch _ | EHandler _ | EEffect _ | ERecord _
@@ -403,34 +425,37 @@ let rec tr_function args body =
 let rec tr_poly_expr (e : Raw.expr) =
   let make data = { e with data = data } in
   match e.data with
-  | EUnit       -> make (EVar      (NPName "()"))
+  | EUnit       -> make (EVar      (NPName (tr_ctor_name CNUnit)))
   | EVar      x -> make (EVar      (NPName x))
   | EImplicit n -> make (EImplicit (NPName n))
   | ECtor     c -> make (EVar      (NPName c))
   | EBOpID    x -> make (EVar      (NPName (make_bop_id x)))
   | EUOpID    x -> make (EVar      (NPName (make_uop_id x)))
+  | EList    [] -> make (EVar      (NPName (tr_ctor_name CNNil)))
 
   | EMethod(e, name) ->
     make (EMethod(tr_expr e, name))
   | ESelect(path, e) ->
     let prepend_path n = path_append path (NPName n) in
     begin match e.data with
-    | EUnit       -> make (EVar      (prepend_path "()"))
+    | EUnit       -> make (EVar      (prepend_path (tr_ctor_name CNUnit)))
     | EVar      x -> make (EVar      (prepend_path x))
     | EImplicit n -> make (EImplicit (prepend_path n))
     | ECtor     c -> make (EVar      (prepend_path c))
     | EBOpID    x -> make (EVar      (prepend_path (make_bop_id x)))
     | EUOpID    x -> make (EVar      (prepend_path (make_uop_id x)))
+    | EList    [] -> make (EVar      (prepend_path (tr_ctor_name CNNil)))
     
     | EWildcard | ENum _ | EStr _ | EParen _ | EFn _ | EApp _
     | EEffect _ | EDefs _ | EMatch _ | ERecord _ | EHandler _ | EExtern _
-    | EAnnot _ | EIf _ | EMethod _ | ESelect _ | EBOp _ | EUOp _ | EPub _ ->
+    | EAnnot _ | EIf _ | EMethod _ | ESelect _ | EBOp _ | EUOp _
+    | EList (_ :: _) | EPub _ ->
       Error.fatal (Error.desugar_error e.pos)
     end
 
   | EWildcard | ENum _ | EStr _ | EParen _ | EFn _ | EApp _
   | EEffect _ | EDefs _ | EMatch _ | ERecord _ | EHandler _ | EExtern _
-  | EAnnot _ | EIf _ | EBOp _ | EUOp _ | EPub _ ->
+  | EAnnot _ | EIf _ | EBOp _ | EUOp _ | EList (_ :: _) | EPub _ ->
     Error.fatal (Error.desugar_error e.pos)
 
 and tr_expr (e : Raw.expr) =
@@ -483,6 +508,16 @@ and tr_expr (e : Raw.expr) =
   | EUOp(op,exp) ->
     let e = tr_expr exp in 
     make (EApp (tr_uop_to_expr op, e))
+  | EList es ->
+    let mk_ctor name = make (EPoly(make (EVar (NPName name)), [], [])) in
+    let cons el xs =
+      let el  = tr_expr el in
+      let pos = Position.join el.pos e.pos in
+      let make data = { pos; data } in
+      make (EApp(make (EApp(mk_ctor (tr_ctor_name (CNBOp "::")), el)), xs))
+    in
+    make (List.fold_right cons es (mk_ctor (tr_ctor_name CNNil))).data
+
   | EWildcard | ERecord _ | EPub _ ->
     Error.fatal (Error.desugar_error e.pos)
 

--- a/src/Parser/Raw.ml
+++ b/src/Parser/Raw.ml
@@ -32,7 +32,12 @@ type name = Lang.Surface.name =
   | NImplicit of iname
 
 (** Names of constructors of ADTs *)
-type ctor_name = string
+type ctor_name =
+  | CNUnit
+  | CNNil
+  | CNId  of string
+  | CNBOp of op_name
+  | CNUOp of op_name
 
 (** Names of methods *)
 type method_name = string
@@ -146,7 +151,7 @@ and expr_data =
   | EImplicit of iname
     (** Named implicit parameter *)
 
-  | ECtor of ctor_name
+  | ECtor of string
     (** ADT constructor *)
 
   | ENum of int
@@ -197,6 +202,9 @@ and expr_data =
 
   | EUOp of op_name node * expr
     (** Unary operator*)
+
+  | EList of expr list
+    (** List-like expression *)
 
   | EPub of expr
     (** Public modifier in patterns *)

--- a/src/Parser/YaccParser.mly
+++ b/src/Parser/YaccParser.mly
@@ -197,9 +197,17 @@ ty_field_list
 
 /* ========================================================================= */
 
+ctor_name
+: BR_OPN  BR_CLS       { CNUnit   }
+| SBR_OPN SBR_CLS      { CNNil    }
+| UID                  { CNId  $1 }
+| BR_OPN op BR_CLS     { CNBOp ($2).data }
+| BR_OPN op DOT BR_CLS { CNUOp ($2).data }
+;
+
 ctor_decl
-: UID                     { make (CtorDecl($1, [])) }
-| UID KW_OF ty_expr_list1 { make (CtorDecl($1, $3)) }
+: ctor_name                     { make (CtorDecl($1, [])) }
+| ctor_name KW_OF ty_expr_list1 { make (CtorDecl($1, $3)) }
 ;
 
 ctor_decl_list1
@@ -395,13 +403,19 @@ expr_simple
 | STR                { make (EStr $1)     }
 | BR_OPN BR_CLS      { make EUnit         }
 | BR_OPN expr BR_CLS { make (EParen $2)   }
-| KW_MATCH expr KW_WITH KW_END { make (EMatch($2, []))}
+| SBR_OPN SBR_CLS    { make (EList [])    }
+| SBR_OPN expr_comma_sep SBR_CLS { make (EList $2)       }
+| KW_MATCH expr KW_WITH KW_END   { make (EMatch($2, [])) }
 | KW_MATCH expr KW_WITH bar_opt match_clause_list KW_END
   { make (EMatch($2, $5)) }
 | CBR_OPN field_list CBR_CLS { make (ERecord $2) }
 | BR_OPN op BR_CLS           { make (EBOpID ($2).data)}
 | BR_OPN op DOT BR_CLS       { make (EUOpID ($2).data)}
+;
 
+expr_comma_sep
+: expr_40                      { [ $1 ]   }
+| expr_40 COMMA expr_comma_sep { $1 :: $3 }
 ;
 
 /* ========================================================================= */

--- a/test/ok/ok0090_lists.dbl
+++ b/test/ok/ok0090_lists.dbl
@@ -1,0 +1,19 @@
+data rec List X = [] | (::) of X, List X
+
+let tl xs =
+  match xs with
+  | []      => []
+  | _ :: xs => xs
+  end
+
+let swap_if_two xs =
+  match xs with
+  | [x,y] => [y,x]
+  | _     => xs
+  end
+
+let dup_hd xs =
+  match xs with
+  | []        => []
+  | (::) x xs => x :: x :: xs
+  end


### PR DESCRIPTION
Resolves #43

- Added unit `()`, nil `[]`, binary, and unary operators in the grammar of ADT constructor declarations.
- Added syntactic sugar for lists `[x,y,z]` in expressions and patterns.
- Updated Prelude and examples to use these new features.