### PR TITLE
Checking if recursive functions have NTerm effect

### DIFF
--- a/src/Lang/Core.mli
+++ b/src/Lang/Core.mli
@@ -185,7 +185,7 @@ type expr =
 
   | ELetRec of (var * ttype * value) list * expr
     (** Mutually recursive let-definitions. Recursive values must be
-      productive. See [CorePriv.Syntax] for details. *)
+      productive. See [CorePriv.WellTypedInvariant] for details. *)
 
   | EApp of value * value
     (** Function application *)

--- a/src/Lang/CorePriv/Syntax.ml
+++ b/src/Lang/CorePriv/Syntax.ml
@@ -47,16 +47,3 @@ and match_clause = {
 }
 
 type program = expr
-
-(** Check if value is productive and can be used as recursive definition.
-  The first parameter is a list of variables mutually defined together with
-  checked value, and therefore must be guarded by lambda-abstractions *)
-let rec is_productive rec_vars v =
-  match v with
-  | VNum _ | VStr _ | VFn _ | VExtern _ -> true
-  | VVar x -> not (List.exists (Var.equal x) rec_vars)
-
-  | VTFun(_, EValue v) -> is_productive rec_vars v
-  | VTFun _ -> false
-
-  | VCtor(_, _, _, vs) -> List.for_all (is_productive rec_vars) vs


### PR DESCRIPTION
Moved productiveness checking in Core to `WellTypedInvariant` and made it more semantic. Now, all non-trivial subexpressions must be guarded by a lambda-abstraction with NTerm effect. See documentation comment in `WellTypedInvariant.check_vtype_productive` for more details.

Fixes #74 