### PR TITLE
Mutually recursive ADTs and labels in Core

### DIFF
--- a/src/Lang/Core.mli
+++ b/src/Lang/Core.mli
@@ -104,21 +104,36 @@ and ctor_type = {
 (** Variables *)
 type var = Var.t
 
-(** ADT definition *)
-type data_def = {
-  dd_tvar  : TVar.ex;
-    (** Type variable, that represents this ADT. *)
+(** Data-like definition (ADT or label) *)
+type data_def =
+  | DD_Data of (** Algebraic datatype *)
+    { tvar  : TVar.ex;
+        (** Type variable, that represents this ADT. *)
 
-  dd_proof : var;
-    (** An irrelevant variables that stores the proof that this ADT has
-      the following constructors. *)
+      proof : var;
+        (** An irrelevant variable that stores the proof that this ADT has
+          the following constructors. *)
 
-  dd_args  : TVar.ex list;
-    (** List of type parameters of this ADT. *)
+      args  : TVar.ex list;
+        (** List of type parameters of this ADT. *)
 
-  dd_ctors : ctor_type list
-    (** List of constructors. *)
-}
+      ctors : ctor_type list
+        (** List of constructors. *)
+    }
+
+  | DD_Label of (** Label *)
+    { tvar      : keffect tvar;
+        (** Type variable that represents effect of this label *)
+
+      var       : var;
+        (** Regular variable that would store the label *)
+
+      delim_tp  : ttype;
+        (** Type of the delimiter *)
+
+      delim_eff : effect
+        (** Effect of the delimiter *)
+    }
 
 (* ========================================================================= *)
 (** Operations on kinds *)
@@ -199,9 +214,6 @@ type expr =
   | EMatch  of expr * value * match_clause list * ttype * effect
     (** Shallow pattern matching. The first parameter is the proof that the
       type of the matched value is an ADT *)
-
-  | ELabel of keffect tvar * var * ttype * effect * expr
-    (** Create a fresh runtime tag for control operators. *)
 
   | EShift of value * var * expr * ttype
     (** Shift-0 operator parametrized by runtime tag, binder for continuation

--- a/src/Lang/CorePriv/Syntax.ml
+++ b/src/Lang/CorePriv/Syntax.ml
@@ -8,12 +8,19 @@ open TypeBase
 
 type var = Var.t
 
-type data_def = {
-  dd_tvar  : TVar.ex;
-  dd_proof : var;
-  dd_args  : TVar.ex list;
-  dd_ctors : ctor_type list
-}
+type data_def =
+  | DD_Data of
+    { tvar  : TVar.ex;
+      proof : var;
+      args  : TVar.ex list;
+      ctors : ctor_type list
+    }
+  | DD_Label of
+    { tvar      : keffect tvar;
+      var       : var;
+      delim_tp  : ttype;
+      delim_eff : effect
+    }
 
 type expr =
   | EValue    of value
@@ -25,7 +32,6 @@ type expr =
   | ETApp      : value * 'k typ -> expr
   | EData     of data_def list * expr
   | EMatch    of expr * value * match_clause list * ttype * effect
-  | ELabel    of keffect tvar * var * ttype * effect * expr
   | EShift    of value * var * expr * ttype
   | EReset    of value * expr * var * expr
   | ERepl     of (unit -> expr) * ttype * effect

--- a/src/ToCore/DataType.ml
+++ b/src/ToCore/DataType.ml
@@ -28,10 +28,11 @@ let prepare_data_def env (dd : S.data_def) =
 let finalize_data_def env (x, (dd : S.data_def)) =
   let (env, args) = List.fold_left_map Env.add_named_tvar env dd.dd_args in
   let ctors = tr_ctor_decls env dd.dd_ctors in
-  { T.dd_tvar  = x;
-    T.dd_proof = dd.dd_proof;
-    T.dd_args  = args;
-    T.dd_ctors = ctors
+  T.DD_Data {
+    tvar  = x;
+    proof = dd.dd_proof;
+    args  = args;
+    ctors = ctors
   }
 
 let tr_data_defs env dds =

--- a/src/ToCore/Main.ml
+++ b/src/ToCore/Main.ml
@@ -53,7 +53,12 @@ let rec tr_expr env (e : S.expr) =
     let eff = Type.tr_effect env eff in
     begin match T.TVar.kind a with
     | KEffect ->
-      T.ELabel(a, l, tp, eff, tr_expr env e)
+      T.EData ([DD_Label
+        { tvar      = a;
+          var       = l;
+          delim_tp  = tp;
+          delim_eff = eff
+        }], tr_expr env e)
     | KType | KArrow _ -> failwith "Internal kind error"
     end
 

--- a/src/TypeErase.ml
+++ b/src/TypeErase.ml
@@ -7,6 +7,12 @@
 module S = Lang.Core
 module T = Lang.Untyped
 
+(** Translate a data or label definition *)
+let tr_data_def (dd : S.data_def) e =
+  match dd with
+  | DD_Data _ -> e
+  | DD_Label lbl -> T.ELabel(lbl.var, e)
+
 (** Translate expression *)
 let rec tr_expr (e : S.expr) =
   match e with
@@ -23,12 +29,10 @@ let rec tr_expr (e : S.expr) =
     tr_value_v v2 (fun v2 ->
     T.EApp(v1, v2)))
   | ETApp(v, _) -> tr_value v
-  | EData(_, e) -> tr_expr e
+  | EData(dds, e) -> List.fold_right tr_data_def dds (tr_expr e)
   | EMatch(_, v, cls, _, _) ->
     tr_value_v v (fun v ->
     T.EMatch(v, List.map tr_clause cls))
-  | ELabel(_, x, _, _, e) ->
-    T.ELabel(x, tr_expr e)
   | EShift(v, x, e, _) ->
     tr_value_v v (fun v ->
     T.EShift(v, x, tr_expr e))


### PR DESCRIPTION
- Removed `ELabel` construct from Core
- Added `DD_Label` constructor to `Core.data_def`

Fixes #77 

Currently, it's hard to test all aspects of this feature, because it is not fully available in Surface. I'm not going to implement it directly in Surface, because it will be covered by #69 almost for free.