### PR TITLE
Separate files as modules

### DIFF
--- a/examples/LWT.dbl
+++ b/examples/LWT.dbl
@@ -2,6 +2,8 @@
   time using first class labels. In opposite to LWT_lexical example, this
   implementation does not lead to memory leaks, because the newly created
   thread do not share an unreachable continuation with the parent thread. *)
+
+import List
  
 (* We start with defining the standard State effect, together with default
   functions for accessing the state. See LWT_lexical example for more
@@ -62,7 +64,7 @@ let sched () =
 
 (* Put a thread to the scheduler queue *)
 let enqueue thr =
-  update (fn q => append q [Thread thr])
+  update (fn q => List.append q [Thread thr])
 
 (* Here, we handle LWT effect. Note that the handler does not provide any
   capability. It only plays a role of the delimiter (reset0) on given label.

--- a/examples/LWT_lexical.dbl
+++ b/examples/LWT_lexical.dbl
@@ -4,6 +4,8 @@
   to effect capabilities we can separate an interface from an implementation
   of algebraic effects. *)
 
+import List
+
 (* We start by defining the standard State effect representing a single
   mutable cell. Note that in DBL an effect signature is an ordinary record
   of functions. A special type parameter `(effect E)` is the effect of these
@@ -58,7 +60,7 @@ handle {effect=Sched} `st =
   mechanism of implicit parameters, this function uses `st capability, without
   mentioning it explicitly. *)
 let enqueue thr =
-  update (fn queue => append queue [thr])
+  update (fn queue => List.append queue [thr])
 
 (* Run the scheduler. It picks one thread from the queue and runs it. *)
 let sched _ =

--- a/examples/Modules/A.dbl
+++ b/examples/Modules/A.dbl
@@ -1,0 +1,3 @@
+import B/C/D
+
+pub let foo = D.id 42

--- a/examples/Modules/B/A.dbl
+++ b/examples/Modules/B/A.dbl
@@ -1,0 +1,2 @@
+pub let id x = x
+pub let bar = 13

--- a/examples/Modules/B/C/D.dbl
+++ b/examples/Modules/B/C/D.dbl
@@ -1,0 +1,4 @@
+(* This import resolves to the absolute path `/Main/B/A`. *)
+import A
+
+pub let id = A.id

--- a/examples/Modules/C.dbl
+++ b/examples/Modules/C.dbl
@@ -1,0 +1,1 @@
+pub let mod_C_value = 0

--- a/examples/Modules/Main.dbl
+++ b/examples/Modules/Main.dbl
@@ -1,0 +1,33 @@
+(** This example serves to showcase the files-as-modules feature.
+
+    The module hierarchy is as follows.
+    ```
+    /
+    ├─ Main
+    │  ├─ Main (this file)
+    │  ├─ A
+    │  ├─ B
+    │  │  ├─ A
+    │  │  └─ C
+    │  │      └─ D
+    │  └─ C
+    ├─ List
+    ⋮
+    ```
+    Modules under `/Main/` are local to this example and follow its directory
+    structure. Additionaly, the module `/List` from the standard library is
+    imported. *)
+
+import List
+
+import A
+import B/C/D as X
+import /Main/B/C/D as Y (* The same import, but as an absolute path. *)
+import B/A as A2
+
+(* Rather than binding a module name, import the module's contents *)
+import open C
+
+let _ =
+  List.iter (fn x => printInt x; printStr "\n")
+    [ X.id A.foo, Y.id A2.bar, mod_C_value ]

--- a/examples/Modules/Main.dbl
+++ b/examples/Modules/Main.dbl
@@ -4,19 +4,24 @@
     ```
     /
     ├─ Main
-    │  ├─ Main (this file)
-    │  ├─ A
+    │  ├─ Main      (this file)
+    │  ├─ A         (imports B/C/D, resolving to /Main/B/C/D)
     │  ├─ B
     │  │  ├─ A
     │  │  └─ C
-    │  │      └─ D
+    │  │      └─ D  (imports A, resolving to /Main/B/A)
     │  └─ C
     ├─ List
     ⋮
     ```
     Modules under `/Main/` are local to this example and follow its directory
     structure. Additionaly, the module `/List` from the standard library is
-    imported. *)
+    imported.
+
+    Relative imports refer to the module which is the closest to the importing
+    module, working upwards through the hierarchy. In this example the module
+    `/Main/B/C/D` imports the relative path `A`, and the nearest matching
+    module is `/Main/B/A`. *)
 
 import List
 

--- a/examples/Prolog.dbl
+++ b/examples/Prolog.dbl
@@ -1,6 +1,8 @@
 (* This example implements a simplified version of Prolog and serves to
   illustrate the combination of implicit parameters and effect capabilities. *)
 
+import List
+
 (* Prolog terms and clauses are fairly standard. Here variables are
   identified by integers and functors by strings. *)
 data rec Term = TVar of Int | TFun of String, List Term
@@ -94,11 +96,11 @@ implicit `eq
 let nub = fix (fn nub xs =>
   match xs with
   | []      => []
-  | x :: xs => x :: nub (filter (fn y => not (`eq x y)) xs)
+  | x :: xs => x :: nub (List.filter (fn y => not (`eq x y)) xs)
   end)
 
-let union xs ys = nub (append xs ys)
-let unions xss = nub (concat xss)
+let union xs ys = nub (List.append xs ys)
+let unions xss = nub (List.concat xss)
 
 let assoc x = fix (fn assoc xs =>
   match xs with
@@ -115,12 +117,12 @@ method vars =
   fix (fn vars t =>
   match t with
   | TVar x    => [x]
-  | TFun _ ts => unions (map vars ts)
+  | TFun _ ts => unions (List.map vars ts)
   end) self
 
 method vars { self = Cl t ts } =
   let `eq (x : Int) = x.equal in
-  union t.vars (unions (map (fn (t : Term) => t.vars) ts))
+  union t.vars (unions (List.map (fn (t : Term) => t.vars) ts))
 
 method rename sub =
   let `eq (x : Int) = x.equal in
@@ -131,11 +133,11 @@ method rename sub =
     | Some y => TVar y
     | None   => TVar x
     end
-  | TFun f ts => TFun f (map rename ts)
+  | TFun f ts => TFun f (List.map rename ts)
   end) self
 
 method rename { self = Cl t ts } sub =
-  Cl (t.rename sub) (map (fn (t : Term) => t.rename sub) ts)
+  Cl (t.rename sub) (List.map (fn (t : Term) => t.rename sub) ts)
 
 (* ========================================================================= *)
 
@@ -182,10 +184,10 @@ let fresh () = `fresh.fresh ()
   all the variables in terms with fresh unification variables. *)
 
 method refresh {self : Term} =
-  self.rename (map (fn x => (x, fresh ())) self.vars)
+  self.rename (List.map (fn x => (x, fresh ())) self.vars)
 
 method refresh {self : Clause} =
-  self.rename (map (fn x => (x, fresh ())) self.vars)
+  self.rename (List.map (fn x => (x, fresh ())) self.vars)
 
 (* ========================================================================= *)
 
@@ -214,7 +216,7 @@ let unify = fix (fn unify (t1 : Term) (t2 : Term) =>
   | t, TVar x =>
     if t.occurs x then fail () else setVar x t
   | TFun f ts1, TFun g ts2 =>
-    if f == g then iter2 {`re = fail} unify ts1 ts2
+    if f == g then List.iter2 {`re = fail} unify ts1 ts2
     else fail ()
   end)
 
@@ -225,7 +227,7 @@ let kbChoose () = `bt.choose (`kb.ask ())
 let eval = fix (fn eval (t : Term) =>
   let Cl t' ts = (kbChoose ()).refresh in
   let _ = unify t t' in
-  iter eval ts)
+  List.iter eval ts)
 
 (* Perform a query by substituting fresh unification variables in a term and
   calling the `eval` function. *)

--- a/examples/Pythagorean.dbl
+++ b/examples/Pythagorean.dbl
@@ -1,6 +1,8 @@
 (* This example demonstrates the use of effect handlers 
   to implement a backtracking search for Pythagorean triples. *)
 
+import List
+
 data Triples = Triple of Int, Int, Int
 
 (* The standard backtracking effect. *)
@@ -46,7 +48,7 @@ let takeFirst (f : {effect=E} -> BT E -> Int ->[E|_] _) (n: Int) =
 (* The function `takeAll` returns list of all triples found. *)
 let takeAll (f : {effect=E} -> BT E -> Int ->[E|_] _) (n: Int) =
   handle bt = BT
-    { flip = effect () / r => append (r True) (r False)
+    { flip = effect () / r => List.append (r True) (r False)
     , fail = effect () => []
     }
   return x => [x]

--- a/examples/Tick.dbl
+++ b/examples/Tick.dbl
@@ -21,6 +21,8 @@
   effects used internally by `f`. This would not be true for dynamic handlers.
 *)
 
+import List
+
 let count (f : {type E} -> (_ ->[|E] _) ->[|E] _) g =
   handle tick = effect _ / k => fn (n : Int) => k () (n + 1)
     return  _ => fn n => n
@@ -30,7 +32,7 @@ let count (f : {type E} -> (_ ->[|E] _) ->[|E] _) g =
 
 (* We can use `count` function to compute a length of a list, by counting
   how many times map function calls identity argument. *)
-let length xs = count (flip map xs) id
+let length xs = count (flip List.map xs) id
 
 (* This code should print 2. *)
 let _ =

--- a/lib/List.dbl
+++ b/lib/List.dbl
@@ -1,0 +1,37 @@
+pub let map f = fix (fn map xs =>
+  match xs with
+  | []      => []
+  | x :: xs => f x :: map xs
+  end)
+
+pub let filter f = fix (fn filter xs =>
+  match xs with
+  | []      => []
+  | x :: xs => if f x then x :: filter xs else filter xs
+  end)
+
+pub let append xs ys = fix (fn append xs =>
+  match xs with
+  | []      => ys
+  | x :: xs => x :: append xs
+  end) xs
+
+pub let concat = fix (fn concat xss =>
+  match xss with
+  | []        => []
+  | xs :: xss => append xs (concat xss)
+  end)
+
+pub let iter f = fix (fn iter xs =>
+  match xs with
+  | []      => ()
+  | x :: xs => let () = f x in iter xs
+  end)
+
+pub let iter2 {`re : {type X} -> Unit ->[|_] X} f =
+  fix (fn iter xs ys =>
+  match xs, ys with
+  | [],      []      => ()
+  | x :: xs, y :: ys => let () = f x y in iter xs ys
+  | _                => `re ()
+  end)

--- a/lib/Prelude.dbl
+++ b/lib/Prelude.dbl
@@ -1,140 +1,103 @@
-data Bool = False | True
+pub data Bool = False | True
 
-data Option A = None | Some of A
+pub data Option A = None | Some of A
 
-data rec Nat = Zero | Succ of Nat
+pub data rec Nat = Zero | Succ of Nat
 
-data rec List A = [] | (::) of A, List A
+pub data rec List A = [] | (::) of A, List A
 
-data Pair X Y = (,) of X, Y
+pub data Pair X Y = (,) of X, Y
 
-let id x = x
+pub let id x = x
 
-let flip f x y = f y x
+pub let flip f x y = f y x
 
-let fst (x, _) = x
-let snd (_, y) = y
+pub let fst (x, _) = x
+pub let snd (_, y) = y
 
-let fix {type A, type B, type E} f =
-  data rec Fix = Fix of (Fix -> A ->[|E] B)
+pub let fix {type A, type B, type E} f =
+  pub data rec Fix = Fix of (Fix -> A ->[|E] B)
   let fi ix x = let Fix fi = ix in f (fi ix) x in
   fi (Fix fi)
 
-let map f = fix (fn map xs =>
-  match xs with
-  | []      => []
-  | x :: xs => f x :: map xs
-  end)
+pub let not b = if b then False else True
 
-let filter f = fix (fn filter xs =>
-  match xs with
-  | []      => []
-  | x :: xs => if f x then x :: filter xs else filter xs
-  end)
+pub method toString = if self then "True" else "False"
 
-let append xs ys = fix (fn append xs =>
-  match xs with
-  | []      => ys
-  | x :: xs => x :: append xs
-  end) xs
+pub method fn (+) = add
+pub method fn (-) = sub
+pub method fn (%) = mod
+pub method fn (/) = div
+pub method fn ( * ) = mul
 
-let concat = fix (fn concat xss =>
-  match xss with
-  | []        => []
-  | xs :: xss => append xs (concat xss)
-  end)
+pub method fn (==) = equal
+pub method fn (!=) = neq
+pub method fn (>)  = gt
+pub method fn (>=) = ge
+pub method fn (<)  = lt
+pub method fn (<=) = le
 
-let iter f = fix (fn iter xs =>
-  match xs with
-  | []      => ()
-  | x :: xs => let () = f x in iter xs
-  end)
+pub method fn (&&&) = land
+pub method fn (^^^) = lxor
+pub method fn (|||) = lor
+pub method fn (>>)  = shiftl
+pub method fn (<<)  = shiftr
+pub method fn (>>>) = ashiftr
 
-let iter2 {`re : {type X} -> Unit ->[|_] X} f =
-  fix (fn iter xs ys =>
-  match xs, ys with
-  | [],      []      => ()
-  | x :: xs, y :: ys => let () = f x y in iter xs ys
-  | _                => `re ()
-  end)
+pub method equal = (extern dbl_eqInt  : Int -> Int -> Bool) self
+pub method neq   = (extern dbl_neqInt : Int -> Int -> Bool) self
+pub method gt    = (extern dbl_gtInt  : Int -> Int -> Bool) self
+pub method lt    = (extern dbl_ltInt  : Int -> Int -> Bool) self
+pub method ge    = (extern dbl_geInt  : Int -> Int -> Bool) self
+pub method le    = (extern dbl_leInt  : Int -> Int -> Bool) self
 
-let not b = if b then False else True
+pub method toString = (extern dbl_intToString : Int -> String) self
 
-method toString = if self then "True" else "False"
+pub method add = (extern dbl_addInt : Int -> Int -> Int) self
+pub method sub = (extern dbl_subInt : Int -> Int -> Int) self
+pub method mul = (extern dbl_mulInt : Int -> Int -> Int) self
 
-method fn (+) = add
-method fn (-) = sub
-method fn (%) = mod
-method fn (/) = div
-method fn ( * ) = mul
-
-method fn (==) = equal
-method fn (!=) = neq
-method fn (>)  = gt
-method fn (>=) = ge
-method fn (<)  = lt
-method fn (<=) = le
-
-method fn (&&&) = land
-method fn (^^^) = lxor
-method fn (|||) = lor
-method fn (>>)  = shiftl
-method fn (<<)  = shiftr
-method fn (>>>) = ashiftr
-
-method equal = (extern dbl_eqInt  : Int -> Int -> Bool) self
-method neq   = (extern dbl_neqInt : Int -> Int -> Bool) self
-method gt    = (extern dbl_gtInt  : Int -> Int -> Bool) self
-method lt    = (extern dbl_ltInt  : Int -> Int -> Bool) self
-method ge    = (extern dbl_geInt  : Int -> Int -> Bool) self
-method le    = (extern dbl_leInt  : Int -> Int -> Bool) self
-
-method toString = (extern dbl_intToString : Int -> String) self
-
-method add = (extern dbl_addInt : Int -> Int -> Int) self
-method sub = (extern dbl_subInt : Int -> Int -> Int) self
-method mul = (extern dbl_mulInt : Int -> Int -> Int) self
-
-method div {`re : {type X} -> Unit ->[|_] X} (n : Int) =
+pub method div {`re : {type X} -> Unit ->[|_] X} (n : Int) =
   if n.equal 0 then `re ()
   else (extern dbl_divInt : Int -> Int -> Int) self n
 
-method mod {`re : {type X} -> Unit ->[|_] X} (n : Int) =
+pub method mod {`re : {type X} -> Unit ->[|_] X} (n : Int) =
   if n.equal 0 then `re ()
   else (extern dbl_modInt : Int -> Int -> Int) self n
 
-method land = (extern dbl_andInt : Int -> Int -> Int) self
-method lor  = (extern dbl_orInt  : Int -> Int -> Int) self
-method lxor = (extern dbl_xorInt : Int -> Int -> Int) self
+pub method land = (extern dbl_andInt : Int -> Int -> Int) self
+pub method lor  = (extern dbl_orInt  : Int -> Int -> Int) self
+pub method lxor = (extern dbl_xorInt : Int -> Int -> Int) self
 
-method shiftl  = (extern dbl_lslInt : Int -> Int -> Int) self
-method shiftr  = (extern dbl_lsrInt : Int -> Int -> Int) self
-method ashiftr = (extern dbl_asrInt : Int -> Int -> Int) self
+pub method shiftl  = (extern dbl_lslInt : Int -> Int -> Int) self
+pub method shiftr  = (extern dbl_lsrInt : Int -> Int -> Int) self
+pub method ashiftr = (extern dbl_asrInt : Int -> Int -> Int) self
 
-method add = (extern dbl_strCat : String -> String -> String) self
+pub method add = (extern dbl_strCat : String -> String -> String) self
 
-method equal = (extern dbl_eqStr  : String -> String -> Bool) self
-method neq   = (extern dbl_neqStr : String -> String -> Bool) self
-method gt    = (extern dbl_gtStr  : String -> String -> Bool) self
-method lt    = (extern dbl_ltStr  : String -> String -> Bool) self
-method ge    = (extern dbl_geStr  : String -> String -> Bool) self
-method le    = (extern dbl_leStr  : String -> String -> Bool) self
+pub method equal = (extern dbl_eqStr  : String -> String -> Bool) self
+pub method neq   = (extern dbl_neqStr : String -> String -> Bool) self
+pub method gt    = (extern dbl_gtStr  : String -> String -> Bool) self
+pub method lt    = (extern dbl_ltStr  : String -> String -> Bool) self
+pub method ge    = (extern dbl_geStr  : String -> String -> Bool) self
+pub method le    = (extern dbl_leStr  : String -> String -> Bool) self
 
-method length = (extern dbl_strLen : String -> Int) self
-method get {`re : {type X} -> Unit ->[|_] X, self : String} (n : Int) =
+pub method length = (extern dbl_strLen : String -> Int) self
+pub method get {`re : {type X} -> Unit ->[|_] X, self : String} (n : Int) =
   if n >= 0 && n < self.length then
     (extern dbl_strGet : String -> Int -> Int) self n
   else `re ()
 
-method makeString {`re : {type X} -> Unit ->[|_] X, self : String} (n : Int) =
+pub method makeString {`re : {type X} -> Unit ->[|_] X, self : String}
+    (n : Int) =
   if n >= 0 && n < 256 then
     (extern dbl_strMake : Int -> String) n
   else `re ()
 
-let printStrLn = extern dbl_printStrLn : String ->[IO] Unit
-let printStr   = extern dbl_printStr   : String ->[IO] Unit
-let printInt   = extern dbl_printInt   : Int ->[IO] Unit
+pub let printStrLn = extern dbl_printStrLn : String ->[IO] Unit
+pub let printStr   = extern dbl_printStr   : String ->[IO] Unit
+pub let printInt   = extern dbl_printInt   : Int ->[IO] Unit
 
-let readLine = extern dbl_readLine : Unit ->[IO] String
+pub let readLine = extern dbl_readLine : Unit ->[IO] String
 
-let exit {type X} = extern dbl_exit : Int ->[IO] X
+pub let exit {type X} = extern dbl_exit : Int ->[IO] X

--- a/src/Config.ml
+++ b/src/Config.ml
@@ -4,15 +4,19 @@
 
 (** Global configuration of the interpreter *)
 
-let prelude_path =
-  let prelude_filename = "Prelude.dbl" in
+let src_extension = ".dbl"
+
+let stdlib_path =
   match Sys.getenv_opt "DBL_LIB" with
-  | Some path -> Filename.concat path prelude_filename
+  | Some path -> path
   | None      ->
     begin match Sys.getenv_opt "OPAM_SWITCH_PREFIX" with
     | Some path ->
-      List.fold_left
-        Filename.concat
-        path [ "lib"; "dbl"; "stdlib"; prelude_filename ]
-    | None      -> "./lib"
+      List.fold_left Filename.concat path [ "lib"; "dbl"; "stdlib" ]
+    | None      -> Filename.concat Filename.current_dir_name "lib"
     end
+
+let local_mod_prefix = "Main"
+
+let lib_search_dirs   : string list ref = ref [ ]
+let local_search_dirs : string list ref = ref [ ]

--- a/src/Parser/Error.ml
+++ b/src/Parser/Error.ml
@@ -19,6 +19,12 @@ let cannot_read_file ?pos ~fname msg =
 let cannot_open_file ?pos ~fname msg =
   (pos, Printf.sprintf "Cannot open file %s (%s)" fname msg)
 
+let cannot_find_module pos path =
+  (Some pos, Printf.sprintf "Cannot find module `%s'" path)
+
+let module_dependency_cycle path =
+  (None, Printf.sprintf "Module dependency cycle detected for `%s'" path)
+
 let unexpected_token pos tok =
   (Some pos, Printf.sprintf "Unexpected token `%s'" tok)
 

--- a/src/Parser/Error.mli
+++ b/src/Parser/Error.mli
@@ -16,6 +16,9 @@ val warn : t -> unit
 val cannot_read_file : ?pos:Position.t -> fname:string -> string -> t
 val cannot_open_file : ?pos:Position.t -> fname:string -> string -> t
 
+val cannot_find_module : Position.t -> string -> t
+val module_dependency_cycle : string -> t
+
 val unexpected_token  : Position.t -> string -> t
 val invalid_character : Position.t -> char -> t
 

--- a/src/Parser/File.ml
+++ b/src/Parser/File.ml
@@ -1,0 +1,41 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Parse a single file with no handling of imports *)
+
+type fname = string
+type def_list = Lang.Surface.def list Lang.Surface.node
+
+let with_in_channel ?pos fname func =
+  match open_in fname with
+  | chan ->
+    begin match func chan with
+    | result -> close_in_noerr chan; result
+    | exception Sys_error msg ->
+      close_in_noerr chan;
+      Error.fatal (Error.cannot_read_file ?pos ~fname msg)
+    | exception ex ->
+      close_in_noerr chan;
+      raise ex
+    end
+  | exception Sys_error msg ->
+    Error.fatal (Error.cannot_open_file ?pos ~fname msg)
+
+let parse_defs ?pos fname =
+  let imports, prog =
+    with_in_channel ?pos fname (fun chan ->
+      let lexbuf = Lexing.from_channel chan in
+      lexbuf.Lexing.lex_curr_p <-
+        { lexbuf.Lexing.lex_curr_p with
+          Lexing.pos_fname = fname
+        };
+      try YaccParser.file Lexer.token lexbuf with
+      | Parsing.Parse_error ->
+        Error.fatal (Error.unexpected_token
+          (Position.of_pp
+            lexbuf.Lexing.lex_start_p
+            lexbuf.Lexing.lex_curr_p)
+          (Lexing.lexeme lexbuf)))
+  in
+  (imports, Desugar.tr_program prog)

--- a/src/Parser/File.mli
+++ b/src/Parser/File.mli
@@ -1,0 +1,11 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Parse a single file with no handling of imports *)
+
+type fname = string
+type def_list = Lang.Surface.def list Lang.Surface.node
+
+(** Parse a single source file into a list of imports and definitions. *)
+val parse_defs : ?pos:Position.t -> fname -> Raw.import list * def_list

--- a/src/Parser/Import.ml
+++ b/src/Parser/Import.ml
@@ -70,9 +70,13 @@ let find_mod prefix (p : Raw.import_path) =
   | IPRelative(p, n) -> find_mod_rel prefix (p, n)
 
 (** Find and parse imported module relative to the path [prefix] and add it
-    to the [mods] map with the absolute mod identifier as the key.
+    to the module graph [mods] with the absolute mod identifier as the map key.
+    Each vertex in the map stores a list of definition and the module's
+    dependencies (graph edges).
+
     Previously imported modules can be passed in the [imported] parameter
-    to avoid including them twice. *)
+    to avoid including them twice. These modules will not be added to the
+    graph, but edges from other vertices may point to them. *)
 let rec parse_import ~imported prefix mods (import : Raw.import) =
   let path, new_name =
     match import.data with

--- a/src/Parser/Import.ml
+++ b/src/Parser/Import.ml
@@ -1,0 +1,177 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Find and parse imported modules *)
+
+module StrSet = Set.Make(String)
+module StrMap = Map.Make(String)
+
+type import_set = StrSet.t
+
+let import_set_empty = StrSet.empty
+
+(** Produce the string representation of a relative path. *)
+let string_of_rel_path (p, n) =
+  List.fold_right (fun n' id -> n' ^ "/" ^ id) p n
+
+(** Produce the string representation of an absolute path. *)
+let string_of_abs_path p =
+  "/" ^ string_of_rel_path p
+
+(** Produce the string representation of a path. *)
+let string_of_path (p : Raw.import_path) =
+  match p with
+  | IPAbsolute(p, n) -> string_of_abs_path (p, n)
+  | IPRelative(p, n) -> string_of_rel_path (p, n)
+
+(** For an absolute module path produce a string suitable for use as an
+    internal module identifier. *)
+let internal_mod_id = string_of_abs_path
+
+(** Find the given file in one of the file system directories in [dirs]. *)
+let find_file_in dirs path =
+  dirs |> List.find_map (fun dirname ->
+    let fname = Filename.concat dirname path in
+    if Sys.file_exists fname then Some fname else None)
+
+(** Convert a module path to a (relative) file path to be found within the
+    file system. *)
+let to_file_path (p, n) =
+  List.fold_right Filename.concat p (n ^ Config.src_extension)
+
+(** Find the file system path for a given absolute module path. *)
+let find_mod_abs (p, n) =
+  match p with
+  | pref :: p when pref = Config.local_mod_prefix ->
+    find_file_in !Config.local_search_dirs (to_file_path (p, n))
+  | [] | _ :: _ ->
+    find_file_in !Config.lib_search_dirs (to_file_path (p, n))
+
+(** Find a module relative to the module directory path [prefix], and return
+    the absolute module path and file system path. *)
+let find_mod_rel prefix p =
+  let rec loop prefix_r (p, n) =
+    let abs_path = (List.rev_append prefix_r p, n) in
+    match find_mod_abs abs_path with
+    | Some fname -> Some (abs_path, fname)
+    | None       ->
+      begin match prefix_r with
+      | []            -> None
+      | _ :: prefix_r -> loop prefix_r (p, n)
+      end
+  in
+  loop (List.rev prefix) p
+
+(** Find the absolute module path and file system path for an import path. *)
+let find_mod prefix (p : Raw.import_path) =
+  match p with
+  | IPAbsolute(p, n) -> find_mod_abs (p, n) |> Option.map (fun f -> (p, n), f)
+  | IPRelative(p, n) -> find_mod_rel prefix (p, n)
+
+(** Find and parse imported module relative to the path [prefix] and add it
+    to the [mods] map with the absolute mod identifier as the key.
+    Previously imported modules can be passed in the [imported] parameter
+    to avoid including them twice. *)
+let rec parse_import ~imported prefix mods (import : Raw.import) =
+  let path, new_name =
+    match import.data with
+    | IImportAs(path, new_name) -> (path, Some new_name)
+    | IImportOpen(path)         -> (path, None)
+  in
+  let path, fname =
+    match find_mod prefix path with
+    | Some path_fname -> path_fname
+    | None            ->
+      Error.fatal (Error.cannot_find_module import.pos (string_of_path path))
+  in
+  let name = internal_mod_id path in
+  let import = { import with data = (name, new_name) } in
+  if StrSet.mem name imported || StrMap.mem name mods then (mods, import)
+  else
+    let new_prefix = fst path in
+    let imports, defs = File.parse_defs ~pos:import.pos fname in
+    let mods = StrMap.add name ([], defs) mods in
+    let mods, imports =
+      parse_imports ~imported new_prefix mods imports in
+    (StrMap.add name (imports, defs) mods, import)
+
+and parse_imports ~imported prefix =
+  List.fold_left_map (parse_import ~imported prefix)
+
+(** Build a graph of all (transitively) imported modules. *)
+let collect_imports ~imported =
+  parse_imports ~imported [ Config.local_mod_prefix ] StrMap.empty
+
+let rec sort_dfs mods name on_path (visited, sorted) =
+  (* TODO: Once recursive module files are implemented cycle detection in this
+     function will likely become redundant. *)
+  if StrSet.mem name on_path then
+    Error.fatal (Error.module_dependency_cycle name)
+  else if StrSet.mem name visited then (visited, sorted)
+  else
+    match StrMap.find_opt name mods with
+    | Some (imports, defs) ->
+      let on_path = StrSet.add name on_path in
+      let imports, defs = StrMap.find name mods in
+      let int_name { Raw.data = (name, _); _ } = name in
+      let visited, sorted =
+        List.fold_right
+          (fun import -> sort_dfs mods (int_name import) on_path)
+          imports (visited, sorted) in
+      (StrSet.add name visited, (name, imports, defs) :: sorted)
+    | None -> (visited, sorted)
+
+(** Topologically sort a graph of modules. *)
+let top_sort mods =
+  let _, sorted =
+    StrMap.fold
+      (fun k _ acc -> sort_dfs mods k StrSet.empty acc)
+      mods (StrSet.empty, []) in
+  List.rev sorted
+
+(** Prepend a module alias based on the given import directive to the list
+    of definitions, or open the module directly if no new name is specified. *)
+let add_import import defs =
+  let open Lang.Surface in
+  let make data = { import with data } in
+  let mod_id, new_name = import.data in
+  match new_name with
+  | Some new_name ->
+    make (DModule(false, new_name, [ make (DOpen(true, NPName mod_id)) ]))
+    :: defs
+  | None ->
+    make (DOpen(false, NPName mod_id)) :: defs
+
+let add_imports = List.fold_right add_import
+
+let import_many imported imports =
+  let mk_mod_def (n, imports, (d : File.def_list)) =
+    let defs = add_imports imports d.data in
+    { d with data = Lang.Surface.DModule(false, n, defs) }
+  in
+  let mods, imports = collect_imports ~imported imports in
+  let defs = List.map mk_mod_def (top_sort mods) in
+  let defs = defs @ add_imports imports [] in
+  let imported = StrSet.add_seq (StrMap.to_seq mods |> Seq.map fst) imported in
+  (imported, defs)
+
+let import_one imported import = import_many imported [ import ]
+
+let import_prelude () =
+  let import : Raw.import =
+    { data = IImportOpen(IPAbsolute([], "Prelude"));
+      pos  = Position.nowhere
+    } in
+  import_one import_set_empty import
+
+let prepend_imports ~use_prelude imports p =
+  let open Lang.Surface in
+  let make data = { p with data } in
+  if use_prelude then
+    let imported, defs1 = import_prelude () in
+    let _,        defs2 = import_many imported imports in
+    make (EDefs(defs1 @ defs2, p))
+  else
+    let _, defs = import_many import_set_empty imports in
+    make (EDefs(defs, p))

--- a/src/Parser/Import.mli
+++ b/src/Parser/Import.mli
@@ -1,0 +1,30 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Find and parse imported modules *)
+
+(** Type used to maintain the set of previously imported modules between
+    calls to functions in this module. *)
+type import_set
+
+(** Empty set of imported modules. *)
+val import_set_empty : import_set
+
+(** Parse one import and its dependencies, and return the list of definitions
+    required by the importer. *)
+val import_one : import_set -> Raw.import -> import_set * Lang.Surface.def list
+
+(** Parse a list of imports and their dependencies, and return the list of
+    definitions required by the importer. *)
+val import_many :
+  import_set -> Raw.import list -> import_set * Lang.Surface.def list
+
+(** Parse the prelude and any dependencies and return the set of imported
+    modules and list of definitions. *)
+val import_prelude : unit -> import_set * Lang.Surface.def list
+
+(** Parse imports and prepend them to a complete program. *)
+val prepend_imports :
+  use_prelude:bool -> Raw.import list -> Lang.Surface.program ->
+  Lang.Surface.program

--- a/src/Parser/Lexer.mll
+++ b/src/Parser/Lexer.mll
@@ -8,6 +8,7 @@
 let kw_map =
   let open YaccParser in
   [ "abstr",    KW_ABSTR
+  ; "as",       KW_AS
   ; "data",     KW_DATA
   ; "effect",   KW_EFFECT
   ; "effrow",   KW_EFFROW
@@ -20,6 +21,7 @@ let kw_map =
   ; "handler",  KW_HANDLER
   ; "if",       KW_IF
   ; "implicit", KW_IMPLICIT
+  ; "import",   KW_IMPORT
   ; "in",       KW_IN
   ; "label",    KW_LABEL
   ; "let",      KW_LET

--- a/src/Parser/Main.ml
+++ b/src/Parser/Main.ml
@@ -6,53 +6,18 @@
 
 type fname = string
 
-let with_in_channel ?pos fname func =
-  match open_in fname with
-  | chan ->
-    begin match func chan with
-    | result -> close_in_noerr chan; result
-    | exception Sys_error msg ->
-      close_in_noerr chan;
-      Error.fatal (Error.cannot_read_file ?pos ~fname msg)
-    | exception ex ->
-      close_in_noerr chan;
-      raise ex
-    end
-  | exception Sys_error msg ->
-    Error.fatal (Error.cannot_open_file ?pos ~fname msg)
-
-let parse_defs ?pos fname =
-  with_in_channel ?pos fname (fun chan ->
-    let lexbuf = Lexing.from_channel chan in
-    lexbuf.Lexing.lex_curr_p <-
-      { lexbuf.Lexing.lex_curr_p with
-        Lexing.pos_fname = fname
-      };
-    try YaccParser.file Lexer.token lexbuf with
-    | Parsing.Parse_error ->
-      Error.fatal (Error.unexpected_token
-        (Position.of_pp
-          lexbuf.Lexing.lex_start_p
-          lexbuf.Lexing.lex_curr_p)
-        (Lexing.lexeme lexbuf)))
-  |> Desugar.tr_program
-
-let parse_lib fname (e : Lang.Surface.program) =
-  let p = parse_defs fname in
-  let make data = { e with data = data } in
-  Lang.Surface.(make (EDefs(p.data, e)))
-
-let parse_file ?pos fname =
-  let p = parse_defs ?pos fname in
-  let make data = { p with data = data } in
-  Lang.Surface.(make (EDefs(p.data, make EUnit)))
+let parse_file ?pos ~use_prelude fname =
+  let imports, prog = File.parse_defs ?pos fname in
+  let make data = { prog with data } in
+  let prog = make (Lang.Surface.EDefs(prog.data, make Lang.Surface.EUnit)) in
+  Import.prepend_imports ~use_prelude imports prog
 
 let make_nowhere data =
   { Lang.Surface.pos  = Position.nowhere
   ; Lang.Surface.data = data
   }
 
-let rec repl_seq () =
+let rec repl_seq imported () =
   flush stderr;
   Printf.printf "> %!";
   let lexbuf = Lexing.from_channel stdin in
@@ -67,10 +32,14 @@ let rec repl_seq () =
 
   | Raw.REPL_Expr e ->
     let def = make_nowhere (Lang.Surface.DReplExpr(Desugar.tr_expr e)) in
-    Seq.Cons(def, repl_seq)
+    Seq.Cons(def, repl_seq imported)
 
   | Raw.REPL_Def def ->
-    Seq.Cons(Desugar.tr_def def, repl_seq)
+    Seq.Cons(Desugar.tr_def def, repl_seq imported)
+
+  | Raw.REPL_Import import ->
+    let imported, defs = Import.import_one imported import in
+    Seq.append (List.to_seq defs) (repl_seq imported) ()
 
   | exception Parsing.Parse_error ->
     Error.fatal (Error.unexpected_token
@@ -79,4 +48,10 @@ let rec repl_seq () =
         lexbuf.Lexing.lex_curr_p)
       (Lexing.lexeme lexbuf))
 
-let repl = make_nowhere (Lang.Surface.ERepl repl_seq)
+let repl ~use_prelude =
+  if use_prelude then
+    let imported, prelude_defs = Import.import_prelude () in
+    let repl_expr = make_nowhere (Lang.Surface.ERepl (repl_seq imported)) in
+    make_nowhere (Lang.Surface.EDefs(prelude_defs, repl_expr))
+  else
+    make_nowhere (Lang.Surface.ERepl (repl_seq Import.import_set_empty))

--- a/src/Parser/Main.mli
+++ b/src/Parser/Main.mli
@@ -8,10 +8,8 @@
 type fname = string
 
 (** Parse single source file *)
-val parse_file : ?pos:Position.t -> fname -> Lang.Surface.program
-
-(** Parse a library and prepend it to the program *)
-val parse_lib : fname -> Lang.Surface.program -> Lang.Surface.program
+val parse_file :
+  ?pos:Position.t -> use_prelude:bool -> fname -> Lang.Surface.program
 
 (** REPL program *)
-val repl : Lang.Surface.program
+val repl : use_prelude:bool -> Lang.Surface.program

--- a/src/Parser/Raw.ml
+++ b/src/Parser/Raw.ml
@@ -276,6 +276,23 @@ and h_clause_data =
   | HCFinally of expr * expr
     (** Finally clause *)
 
+(** Path to an imported module tagged as absolute or relative *)
+type import_path =
+  | IPAbsolute of module_name list * module_name
+  | IPRelative of module_name list * module_name
+
+(** Base name of imported module *)
+let import_path_name = function
+  | IPAbsolute(_, n) | IPRelative(_, n) -> n
+
+(** Module import *)
+type import = import_data node
+and import_data =
+  | IImportAs of import_path * module_name
+    (** Import as given module name *)
+  | IImportOpen of import_path
+    (** Import and immediately open the module *)
+
 (** Program *)
 type program = def list node
 
@@ -289,3 +306,6 @@ type repl_cmd =
   
   | REPL_Def  of def
     (** Provide a new definition in a REPL session *)
+
+  | REPL_Import of import
+    (** Import a module *)

--- a/src/Parser/dune
+++ b/src/Parser/dune
@@ -3,4 +3,4 @@
 
 (library
   (name parser)
-  (libraries str interpLib lang utils))
+  (libraries str interpLib lang utils config))

--- a/src/Pipeline.mli
+++ b/src/Pipeline.mli
@@ -10,6 +10,9 @@ val dump_core : bool ref
 (** Include the prelude only if this flag is set. *)
 val use_prelude : bool ref
 
+(** Include the standard library only if this flag is set. *)
+val use_stdlib : bool ref
+
 (** Run in REPL mode *)
 val run_repl : unit -> unit
 

--- a/src/dbl.ml
+++ b/src/dbl.ml
@@ -22,6 +22,10 @@ let cmd_args_options = Arg.align
     Arg.Clear Pipeline.use_prelude,
     " Disable the prelude";
 
+    "-no-stdlib",
+    Arg.Clear Pipeline.use_stdlib,
+    " Do not use the standard library";
+
     "-verbose-internal-errors",
     Arg.Set InterpLib.InternalError.verbose,
     " Make internal errors more verbose (for debugging only)"

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,10 @@
+(library
+ (name config)
+ (modules config))
+
 (executable
   (name dbl)
   (modes byte exe)
   (public_name dbl)
-  (libraries interpLib parser typeInference toCore))
+  (libraries interpLib parser typeInference toCore)
+  (modules dbl eval pipeline typeErase))

--- a/test/test_suite
+++ b/test/test_suite
@@ -5,7 +5,7 @@ function simple_run_tests {
   done
 }
 
-run_with_flags simple_run_tests "-no-prelude"
+run_with_flags simple_run_tests "-no-prelude -no-stdlib"
 
 function simple_examples {
   simple_test examples/Tick.dbl
@@ -13,6 +13,7 @@ function simple_examples {
   simple_test examples/LWT.dbl
   simple_test examples/Prolog.dbl
   simple_test examples/Pythagorean.dbl
+  simple_test examples/Modules/Main.dbl
 }
 
 run_with_flags simple_examples ""
@@ -24,4 +25,4 @@ function simple_error_tests {
   done
 }
 
-run_with_flags simple_error_tests "-no-prelude"
+run_with_flags simple_error_tests "-no-prelude -no-stdlib"


### PR DESCRIPTION
This commit adds support for separating a program into multiple files.

- Files are currently handled entirely in the parsing phase. In batch mode, each file consists of a preamble with import directives, and a list of definitions as before. In the REPL `import` can be used as a command at any point.
- In batch mode all imports are prepended to the program in one go before entering the type checker.
- Import commands in the REPL cause the required, but not previously imported, definitions to be added onto the lazy list of definitions for processing before later commands.
- In either mode the implementation shouldn't evaluate the definitions in a given module more than once.
- 3 kinds of imports: `import P as X` (makes the module available under the module name X), `import P` (uses the base name from P as the imported module name), `import open P` (no module name is introduced; instead the public definitions from `P` are added directly to the current namespace, like with `open M`).
- Module paths are separated with `/` and can be absolute or relative. Absolute paths beginning with `/Main/` are regarded as local to the project and are looked for in the provided file's directory, or the current working directory in REPL mode. Other absolute paths are library modules. Relative paths are resolved to absolute paths by trying to find a matching path as "close" in the hierarchy to the importing module as possible.
- The current design allows multiple directories to be searched for modules, though this is not currently exposed to the user.
- `-no-stdlib` command-line option disables adding the standard library to the interpreter's library module search path.

Fixes #35.

I added on the REPL support as a last-minute thing, but I'm not sure if the implementation makes sense. Also, since multi-file programs don't fit that well into the current test framework, I added a (gibberish) example to the `examples` directory. Finally, I have some doubts about relative module path resolution as implemented currently (`Parser/Import.ml:53`). When searching for `A/B`, if the `A` directory exists at the current level but has no `B` module, it will go up a level in the hierarchy and keep looking for `A/B`. Maybe the implementation should insist on looking for `B` in the first `A` directory found instead, and report an error if it doesn't exist.