### PR TITLE
Recursive methods and better polymorphic recursion

### DIFF
--- a/examples/Prolog.dbl
+++ b/examples/Prolog.dbl
@@ -162,20 +162,18 @@ let getVar x =
   term, accounting for the instantiation of unification variables.
   In a realistic implementation we would keep terms that haven't been viewed
   abstract to prevent accidentally pattern-matching on them. *)
-method view =
-  let rec view t =
-    match t with
-    | TVar x    =>
-      match getVar x with
-      | Some t =>
-        let t = view t in
-        let _ = setVar x t in
-        t
-      | None   => t
-      end
-    | TFun f ts => t
+method rec view {self : Term} =
+  match self with
+  | TVar x    =>
+    match getVar x with
+    | Some t =>
+      let t = t.view in
+      let _ = setVar x t in
+      t
+    | None   => self
     end
-  in view self
+  | TFun f ts => self
+  end
 
 (* As with `st, the capability to generate fresh identifiers `fresh is also
   declared implicit. *)

--- a/test/ok/ok0101_recursiveMethod.dbl
+++ b/test/ok/ok0101_recursiveMethod.dbl
@@ -1,0 +1,9 @@
+rec
+  data List X = [] | (::) of X, List X
+
+  method map {self : List _} f =
+    match self with
+    | []      => []
+    | x :: xs => x :: xs.map f
+    end
+end

--- a/test/ok/ok0102_polymorphicRecursion.dbl
+++ b/test/ok/ok0102_polymorphicRecursion.dbl
@@ -1,0 +1,8 @@
+data Sqr A = (,) of A, A
+data rec Tree A = Leaf | Node of Tree (Sqr A)
+
+method rec map {A,B, self : Tree A} (f : A ->[|_] B) =
+  match self with
+  | Leaf   => Leaf
+  | Node t => Node (t.map (fn (x, y) => (f x, f y)))
+  end : Tree B


### PR DESCRIPTION
Now, guessing the type of a recursive value looks into lambda abstractions and type annotations inside a value in order to gather more information about the type.

Fixes #70