### PR TITLE
Types and values attached to delimiter in Core

### DIFF
--- a/src/Lang/Core.mli
+++ b/src/Lang/Core.mli
@@ -67,9 +67,22 @@ type _ typ =
   | TForall : 'k tvar * ttype -> ktype typ
     (** Polymorphic type *)
 
-  | TLabel   : effect * ttype * effect -> ktype typ
-    (** Type of first class label. It stores effect of a label as well as
-      type and effect of the context of the delimiter ([EReset]) *)
+  | TLabel : (** Type of the first class label *)
+    { effect    : effect;
+        (** The effect of this label *)
+
+      tvars     : TVar.ex list;
+        (** List of types stored at each delimiter of this label *)
+
+      val_types : ttype list;
+        (** List of types of values stored at each delimiter of this label *)
+
+      delim_tp  : ttype;
+        (** Type of the delimiter *)
+
+      delim_eff : effect
+        (** Effect of the delimiter *)
+    } -> ktype typ
 
   | TData    : ttype * ctor_type list -> ktype typ
     (** Proof of the shape of ADT.
@@ -127,6 +140,12 @@ type data_def =
 
       var       : var;
         (** Regular variable that would store the label *)
+
+      tvars     : TVar.ex list;
+        (** List of existential types stored at each delimiter of this label. *)
+
+      val_types : ttype list;
+        (** List of types of values stored at each delimiter of this label. *)
 
       delim_tp  : ttype;
         (** Type of the delimiter *)
@@ -215,13 +234,14 @@ type expr =
     (** Shallow pattern matching. The first parameter is the proof that the
       type of the matched value is an ADT *)
 
-  | EShift of value * var * expr * ttype
-    (** Shift-0 operator parametrized by runtime tag, binder for continuation
+  | EShift of value * TVar.ex list * var list * var * expr * ttype
+    (** Shift-0 operator parametrized by runtime tag, binders of existential
+      types and values stored at the delimiter, binder for continuation
       variable, body, and the type of the whole expression. *)
 
-  | EReset of value * expr * var * expr
-    (** Reset-0 operator parametrized by runtime tag, body, and the return
-      clause *)
+  | EReset of value * Type.ex list * value list * expr * var * expr
+    (** Reset-0 operator parametrized by runtime tag, list of types and values
+      stored at this delimiter, body, and the return clause *)
 
   | ERepl of (unit -> expr) * ttype * effect
     (** REPL. It is a function that prompts user for another input. It returns

--- a/src/Lang/CorePriv/Subst.ml
+++ b/src/Lang/CorePriv/Subst.ml
@@ -46,8 +46,15 @@ let rec in_type_rec : type k. t -> k typ -> k typ =
   | TForall(x, tp) ->
     let (sub, x) = add_tvar sub x in
     TForall(x, in_type_rec sub tp)
-  | TLabel(eff, tp0, eff0) ->
-    TLabel(in_type_rec sub eff, in_type_rec sub tp0, in_type_rec sub eff0)
+  | TLabel lbl ->
+    let effect = in_type_rec sub lbl.effect in
+    let (sub, tvars) = add_tvars sub lbl.tvars in
+    TLabel
+      { effect; tvars;
+        val_types = List.map (in_type_rec sub) lbl.val_types;
+        delim_tp  = in_type_rec sub lbl.delim_tp;
+        delim_eff = in_type_rec sub lbl.delim_eff
+      }
   | TData(tp, ctors) ->
     TData(in_type_rec sub tp, List.map (in_ctor_type_rec sub) ctors)
   | TApp(tp1, tp2) ->

--- a/src/Lang/CorePriv/Syntax.ml
+++ b/src/Lang/CorePriv/Syntax.ml
@@ -18,6 +18,8 @@ type data_def =
   | DD_Label of
     { tvar      : keffect tvar;
       var       : var;
+      tvars     : TVar.ex list;
+      val_types : ttype list;
       delim_tp  : ttype;
       delim_eff : effect
     }
@@ -32,8 +34,8 @@ type expr =
   | ETApp      : value * 'k typ -> expr
   | EData     of data_def list * expr
   | EMatch    of expr * value * match_clause list * ttype * effect
-  | EShift    of value * var * expr * ttype
-  | EReset    of value * expr * var * expr
+  | EShift    of value * TVar.ex list * var list * var * expr * ttype
+  | EReset    of value * Type.ex list * value list * expr * var * expr
   | ERepl     of (unit -> expr) * ttype * effect
   | EReplExpr of expr * string * expr
 

--- a/src/Lang/CorePriv/TypeBase.ml
+++ b/src/Lang/CorePriv/TypeBase.ml
@@ -85,7 +85,13 @@ type _ typ =
   | TVar     : 'k tvar -> 'k typ
   | TArrow   : ttype * ttype * effect -> ktype typ
   | TForall  : 'k tvar * ttype -> ktype typ
-  | TLabel   : effect * ttype * effect -> ktype typ
+  | TLabel   :
+    { effect    : effect;
+      tvars     : TVar.ex list;
+      val_types : ttype list;
+      delim_tp  : ttype;
+      delim_eff : effect
+    } -> ktype typ
   | TData    : ttype * ctor_type list -> ktype typ
   | TApp     : ('k1 -> 'k2) typ * 'k1 typ -> 'k2 typ
 

--- a/src/Lang/CorePriv/WellTypedInvariant.ml
+++ b/src/Lang/CorePriv/WellTypedInvariant.ml
@@ -126,8 +126,15 @@ let rec tr_type : type k. Env.t -> k typ -> k typ =
   | TForall(x, tp) ->
     let (env, x) = Env.add_tvar env x in
     TForall(x, tr_type env tp)
-  | TLabel(eff, tp0, eff0) ->
-    TLabel(tr_type env eff, tr_type env tp0, tr_type env eff0)
+  | TLabel lbl ->
+    let effect = tr_type env lbl.effect in
+    let (env, tvars) = Env.add_tvars env lbl.tvars in
+    TLabel
+      { effect; tvars;
+        val_types = List.map (tr_type env) lbl.val_types;
+        delim_tp  = tr_type env lbl.delim_tp;
+        delim_eff = tr_type env lbl.delim_eff
+      }
   | TData(tp, ctors) ->
     TData(tr_type env tp, List.map (tr_ctor_type env) ctors)
   | TApp(tp1, tp2) ->
@@ -206,9 +213,13 @@ let finalize_data_def (env, dd_eff) dd =
     (env, dd_eff)
 
   | DD_Label lbl ->
-    let tp  = tr_type env lbl.delim_tp in
-    let eff = tr_type env lbl.delim_eff in
-    let env = Env.add_var env lbl.var (TLabel(TVar lbl.tvar, tp, eff)) in
+    let effect = TVar lbl.tvar in
+    let (eff_env, tvars) = Env.add_tvars env lbl.tvars in
+    let val_types = List.map (tr_type eff_env) lbl.val_types in
+    let delim_tp  = tr_type eff_env lbl.delim_tp in
+    let delim_eff = tr_type eff_env lbl.delim_eff in
+    let lbl_tp = TLabel { effect; tvars; val_types; delim_tp; delim_eff } in
+    let env = Env.add_var env lbl.var lbl_tp in
     (* We add nterm effect, since generation of a fresh label is not pure *)
     (env, Effect.join Effect.nterm dd_eff)
 
@@ -290,13 +301,19 @@ let rec infer_type_eff env e =
       failwith "Internal type error"
     end
 
-  | EShift(v, k, body, tp) ->
+  | EShift(v, tvs, xs, k, body, tp) ->
     begin match infer_vtype env v with
-    | TLabel(eff, tp0, eff0) ->
+    | TLabel lbl ->
       let tp = tr_type env tp in
+      let (env, sub) = tr_tvars_sub env Subst.empty tvs lbl.tvars in
+      let tps  = List.map (Subst.in_type sub) lbl.val_types in
+      let tp0  = Subst.in_type sub lbl.delim_tp in
+      let eff0 = Subst.in_type sub lbl.delim_eff in
+      assert (List.length xs = List.length tps);
+      let env = List.fold_left2 Env.add_var env xs tps in
       let env = Env.add_var env k (TArrow(tp, tp0, eff0)) in
       check_type_eff env body tp0 eff0;
-      (tp, eff)
+      (tp, lbl.effect)
 
     | TUVar _ ->
       InterpLib.InternalError.report
@@ -305,13 +322,21 @@ let rec infer_type_eff env e =
       failwith "Internal type error"
     end
 
-  | EReset(v, body, x, ret) ->
+  | EReset(v, tps, vs, body, x, ret) ->
     begin match infer_vtype env v with
-    | TLabel(eff, tp0, eff0) ->
-      let x_tp = infer_type_check_eff env body (TEffJoin(eff, eff0)) in
+    | TLabel lbl ->
+      let sub = tr_types_sub env Subst.empty lbl.tvars tps in
+      if List.length lbl.val_types <> List.length vs then
+        failwith "Internal type error (constructor arity)";
+      List.iter2 (check_vtype env) vs
+        (List.map (Subst.in_type sub) lbl.val_types);
+      let delim_tp = Subst.in_type sub lbl.delim_tp in
+      let delim_eff = Subst.in_type sub lbl.delim_eff in
+      let x_tp =
+        infer_type_check_eff env body (TEffJoin(lbl.effect, delim_eff)) in
       let env = Env.add_var env x x_tp in
-      check_type_eff env ret tp0 eff0;
-      (tp0, eff0)
+      check_type_eff env ret delim_tp delim_eff;
+      (delim_tp, delim_eff)
 
     | TUVar _ ->
       InterpLib.InternalError.report

--- a/src/Lang/Untyped.ml
+++ b/src/Lang/Untyped.ml
@@ -27,11 +27,15 @@ type expr =
   | ELabel of var * expr
     (** Generating fresh runtime label *)
 
-  | EShift of value * var * expr
-    (** Shift-0 operator at given runtime label *)
+  | EShift of value * var list * var * expr
+    (** Shift-0 operator at given runtime label (the first parameter). The
+      second parameter is a list of variables that represents values stored at
+      the delimiter. The third parameter is a continuation variable. *)
 
-  | EReset of value * expr * var * expr
-    (** Shift-0 operator at given runtime label and with a return clause *)
+  | EReset of value * value list * expr * var * expr
+    (** Shift-0 operator at given runtime label (the first parameter) and
+      which stores a list of values (the second parameter). The last two
+      parameters represent a return clause *)
 
   | ERepl of (unit -> expr)
     (** REPL. It is a function that prompts user for another input. It returns

--- a/src/Lang/Untyped.ml
+++ b/src/Lang/Untyped.ml
@@ -33,7 +33,7 @@ type expr =
       the delimiter. The third parameter is a continuation variable. *)
 
   | EReset of value * value list * expr * var * expr
-    (** Shift-0 operator at given runtime label (the first parameter) and
+    (** Reset-0 operator at given runtime label (the first parameter) and
       which stores a list of values (the second parameter). The last two
       parameters represent a return clause *)
 

--- a/src/ToCore/DataType.ml
+++ b/src/ToCore/DataType.ml
@@ -73,6 +73,8 @@ let finalize_data_def env (dd : data_def) =
     T.DD_Label {
       tvar      = dd.tvar;
       var       = dd.var;
+      tvars     = [];
+      val_types = [];
       delim_tp  = Type.tr_ttype  env dd.delim_tp;
       delim_eff = Type.tr_effect env dd.delim_eff
     }

--- a/src/ToCore/Main.ml
+++ b/src/ToCore/Main.ml
@@ -56,11 +56,11 @@ let rec tr_expr env (e : S.expr) =
     let r_body = tr_expr env ret_body in
     T.ELet(hx, T.ETApp(hv, h_eff),
       T.ELet(cap_var, T.EApp(T.VVar hx, lv),
-        T.EReset(lv, tr_expr env body, ret_var, r_body)))))
+        T.EReset(lv, [], [], tr_expr env body, ret_var, r_body)))))
 
   | EEffect(l, x, body, tp) ->
     tr_expr_v env l (fun lv ->
-    T.EShift(lv, x, tr_expr env body, Type.tr_ttype env tp))
+    T.EShift(lv, [], [], x, tr_expr env body, Type.tr_ttype env tp))
 
   | ERepl(func, tp, eff) ->
     let tp  = Type.tr_ttype  env tp  in
@@ -122,8 +122,14 @@ and tr_expr_v env (e : S.expr) cont =
     | KEffect ->
       let tp  = Type.tr_ttype  env tp in
       let eff = Type.tr_effect env eff in
-      cont (T.VTFun(a, T.EValue(T.VFn(lx, TLabel(TVar a, tp, eff),
-        tr_expr env h))))
+      let lbl_tp = T.TLabel
+        { effect    = TVar a;
+          tvars     = [];
+          val_types = [];
+          delim_tp  = tp;
+          delim_eff = eff
+        } in
+      cont (T.VTFun(a, T.EValue(T.VFn(lx, lbl_tp, tr_expr env h))))
     | _ ->
       failwith "Internal kind error"
     end

--- a/src/ToCore/Type.ml
+++ b/src/ToCore/Type.ml
@@ -79,7 +79,13 @@ and tr_type env tp =
       let tp0  = tr_ttype env tp0 in
       let eff0 = tr_effect env eff0 in
       T.Type.Ex (TForall(x,
-        TArrow(TLabel(TVar x, tp0, eff0), tp, TEffPure)))
+        TArrow(TLabel
+          { effect    = TVar x;
+            tvars     = [];
+            val_types = [];
+            delim_tp  = tp0;
+            delim_eff = eff0
+          }, tp, TEffPure)))
     | _ ->
       failwith "Internal kind error"
     end
@@ -87,7 +93,13 @@ and tr_type env tp =
     let eff  = tr_effect env eff in
     let tp0  = tr_ttype  env tp0 in
     let eff0 = tr_effect env eff0 in
-    T.Type.Ex (TLabel(eff, tp0, eff0))
+    T.Type.Ex (TLabel
+      { effect    = eff;
+        tvars     = [];
+        val_types = [];
+        delim_tp  = tp0;
+        delim_eff = eff0
+      })
   | TApp(tp1, tp2) ->
     let (Ex tp1) = tr_type env tp1 in
     let (Ex tp2) = tr_type env tp2 in

--- a/src/TypeErase.ml
+++ b/src/TypeErase.ml
@@ -33,12 +33,13 @@ let rec tr_expr (e : S.expr) =
   | EMatch(_, v, cls, _, _) ->
     tr_value_v v (fun v ->
     T.EMatch(v, List.map tr_clause cls))
-  | EShift(v, x, e, _) ->
+  | EShift(v, _, xs, x, e, _) ->
     tr_value_v v (fun v ->
-    T.EShift(v, x, tr_expr e))
-  | EReset(v, body, x, ret) ->
+    T.EShift(v, xs, x, tr_expr e))
+  | EReset(v, _, vs, body, x, ret) ->
     tr_value_v v (fun v ->
-    T.EReset(v, tr_expr body, x, tr_expr ret))
+    tr_value_vs vs (fun vs ->
+    T.EReset(v, vs, tr_expr body, x, tr_expr ret)))
   | ERepl(func, _, _) ->
     T.ERepl (fun () -> tr_expr (func ()))
   | EReplExpr(e1, tp, e2) ->


### PR DESCRIPTION
Added types and values attached to delimiter in Core and Untyped intermediate languages. These features are not used by `ToCore` translation, yet.

I've implemented them slightly differently than the proposed approach during the discussion with @forell. When we separate label signatures (with irrelevant proofs similar to the ones in ADT) from labels, as we discussed, we land in inconvenient situation in Core when labels are mutually recursive with signatures: label definition (which lives on the level of types) depends on value component of signautre (the proof). This in turn makes type-checking more complicated.

Therefore, I decided to simply enrich label type. I hope, the proposed solution for Surface/Unif can still be implemented, by translating effect signatures to ADTs with single label fields in Core, and translating signature constraints to data constraints.

Fixes #101 