### PR TITLE
Better position printing in error messages

### DIFF
--- a/src/InterpLib/Error.ml
+++ b/src/InterpLib/Error.ml
@@ -29,12 +29,12 @@ let report ?pos ~cls msg =
     | Warning -> "warning"
     | Note    -> "note"
   in
-  match pos with
+  match Option.bind pos Position.get_text_range with
   | None ->
     Printf.eprintf "%s: %s\n" name msg
   | Some pos ->
     Printf.eprintf "%s: %s\n%s\n"
-      name msg (Position.get_text_range pos)
+      name msg pos
 
 let assert_no_error () =
   if !err_counter <> 0 then

--- a/src/InterpLib/Error.ml
+++ b/src/InterpLib/Error.ml
@@ -33,8 +33,8 @@ let report ?pos ~cls msg =
   | None ->
     Printf.eprintf "%s: %s\n" name msg
   | Some pos ->
-    Printf.eprintf "%s: %s: %s\n"
-      (Position.to_string pos) name msg
+    Printf.eprintf "%s: %s\n%s\n"
+      name msg (Position.get_text_range pos)
 
 let assert_no_error () =
   if !err_counter <> 0 then

--- a/src/InterpLib/Error.ml
+++ b/src/InterpLib/Error.ml
@@ -29,12 +29,15 @@ let report ?pos ~cls msg =
     | Warning -> "warning"
     | Note    -> "note"
   in
-  match Option.bind pos Position.get_text_range with
-  | None ->
-    Printf.eprintf "%s: %s\n" name msg
-  | Some pos ->
+  match pos, Option.bind pos Position.get_text_range with
+  | Some pos, None ->
+    Printf.eprintf "%s: %s: %s\n"
+      (Position.to_string pos) name msg
+  | _, Some pos ->
     Printf.eprintf "%s: %s\n%s\n"
       name msg pos
+  | None, _ ->
+    Printf.eprintf "%s: %s\n" name msg
 
 let assert_no_error () =
   if !err_counter <> 0 then

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -99,91 +99,92 @@ let to_string pos =
 
 module PrettyPrinting =
 struct
+  type underline_options =
+    | NoUnderline
+    | UnderlineBegining
+    | UnderlineIfOneLine
+    | UnderlineAlways
 
-type underline_option =
-  | NoUnderline
-  | UnderlineBegining
-  | UnderlineIfOneLine
-  | UnderlineAlways
+  type options = {
+    context : int;
+    underline : t -> underline_options;
+    add_line_numbers : bool;
+  }
 
-type pretty_print_options = {
-  context : int;
-  underline : underline_option;
-  add_line_numbers : bool;
-}
-
-let default_options = {
-  context = 0;
-  underline = UnderlineIfOneLine;
-  add_line_numbers = true;
-}
-
-let generate_underline start_cnum len =
-  if len <= 0 then "" else
-  let underline = String.make len '^' in
-  let padding = String.make (start_cnum - 1) ' ' in
-  padding ^ underline
-
-let add_underline pos options (i, line) : (int option * string) Seq.t =
-  match options.underline, i with
-  | NoUnderline, _ -> Seq.return (i, line)
-  | (UnderlineIfOneLine | UnderlineAlways), Some j
-      when pos.pos_start_line = pos.pos_end_line
-      && pos.pos_start_line = j ->
-    let underline =
-      generate_underline (start_column pos) pos.pos_length in
-    Seq.cons (i, line) (Seq.return (None, underline))
-  | UnderlineIfOneLine, _ -> Seq.return (i, line)
-  | UnderlineBegining, Some j
-      when pos.pos_start_line = j ->
-    let underline =
-      generate_underline (start_column pos) 1 in
-    Seq.cons (i, line) (Seq.return (None, underline))
-  | UnderlineBegining, _ -> Seq.return (i, line)
-  | UnderlineAlways, Some j
-      when j = pos.pos_start_line ->
-    let underline =
-      generate_underline (start_column pos) (String.length line - start_column pos) in
-    Seq.cons (i, line) (Seq.return (None, underline))
-  | UnderlineAlways, Some j
-      when j = pos.pos_end_line ->
-    let underline =
-      generate_underline 0 (end_column pos) in
-    Seq.cons (i, line) (Seq.return (None, underline))
-  | UnderlineAlways, Some j
-      when j > pos.pos_start_line && j < pos.pos_end_line ->
-    let underline =
-      generate_underline 0 (String.length line) in
-    Seq.cons (i, line) (Seq.return (None, underline))
-  | UnderlineAlways, _ -> Seq.return (i, line)
-
-
-let add_line_number options end_line =
-  let align_to = Float.of_int end_line
-    |> Float.log10
-    |> Float.to_int
-  in
-  fun (i, line) ->
-    if not options.add_line_numbers then line else
-    match i with
-    | None -> String.make (align_to + 3) ' ' ^ "| " ^ line
-    | Some i ->
-     Printf.sprintf " %*d | %s" (align_to + 1) i line
+  let default_options = {
+    context = 1;
+    underline = (fun _ -> UnderlineIfOneLine);
+    add_line_numbers = true;
+  }
 
 end
 
 (** Get text from file from given position *)
-let get_text_range ?(options = PrettyPrinting.default_options) (pos : t)=
-  let ch = open_in pos.pos_fname in
+let get_text_range ?(options = PrettyPrinting.default_options) ?channel (pos : t)=
+  let generate_underline start_cnum len =
+    if len <= 0 then "" else
+    let underline = String.make len '^' in
+    let padding = String.make (start_cnum - 1) ' ' in
+    padding ^ underline
+  in
+  let add_underline (i, line) : (int option * string) Seq.t =
+    match options.underline pos, i with
+    | NoUnderline, _ -> Seq.return (i, line)
+    | (UnderlineIfOneLine | UnderlineAlways), Some j
+        when pos.pos_start_line = pos.pos_end_line
+        && pos.pos_start_line = j ->
+      let underline =
+        generate_underline (start_column pos) pos.pos_length in
+      Seq.cons (i, line) (Seq.return (None, underline))
+    | UnderlineIfOneLine, _ -> Seq.return (i, line)
+    | UnderlineBegining, Some j
+        when pos.pos_start_line = j ->
+      let underline =
+        generate_underline (start_column pos) 1 in
+      Seq.cons (i, line) (Seq.return (None, underline))
+    | UnderlineBegining, _ -> Seq.return (i, line)
+    | UnderlineAlways, Some j
+        when j = pos.pos_start_line ->
+      let underline =
+        generate_underline (start_column pos) (String.length line - start_column pos) in
+      Seq.cons (i, line) (Seq.return (None, underline))
+    | UnderlineAlways, Some j
+        when j = pos.pos_end_line ->
+      let underline =
+        generate_underline 0 (end_column pos) in
+      Seq.cons (i, line) (Seq.return (None, underline))
+    | UnderlineAlways, Some j
+        when j > pos.pos_start_line && j < pos.pos_end_line ->
+      let underline =
+        generate_underline 0 (String.length line) in
+      Seq.cons (i, line) (Seq.return (None, underline))
+    | UnderlineAlways, _ -> Seq.return (i, line)
+  in
+  let add_line_number end_line =
+    let align_to = Float.of_int end_line
+      |> Float.log10
+      |> Float.to_int
+    in
+    fun (i, line) ->
+      if not options.add_line_numbers then line else
+      match i with
+      | None -> String.make (align_to + 3) ' ' ^ "| " ^ line
+      | Some i ->
+       Printf.sprintf " %*d | %s" (align_to + 1) i line
+  in
+  let ch = match channel with
+    | None -> open_in pos.pos_fname
+    | Some ch -> ch
+  in
   let lines = In_channel.input_lines ch
     |> List.to_seq
     |> Seq.zip (Seq.ints 1 |> Seq.map Option.some)
-    |> Seq.drop (pos.pos_start_line - 1 - options.context)
-    |> Seq.take (pos.pos_end_line - pos.pos_start_line + 1 + options.context)
-    |> Seq.flat_map (PrettyPrinting.add_underline pos options)
-    |> Seq.map (PrettyPrinting.add_line_number options pos.pos_end_line)
+    |> Seq.drop (pos.pos_start_line - 1 - options.context |> Int.max 0)
+    |> Seq.take (pos.pos_end_line - pos.pos_start_line + 1 + 2*options.context)
+    |> Seq.flat_map add_underline
+    |> Seq.map (add_line_number pos.pos_end_line)
   in
-  close_in ch;
+  if Option.is_none channel then close_in ch;
   let pp_file_name = "-> " ^ pos.pos_fname ^ "\n" in
   pp_file_name ^ String.concat "\n" @@ List.of_seq lines
 

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -180,15 +180,6 @@ let get_text_range ?(options = PrettyPrinting.default_options) ?channel (pos : t
        Printf.sprintf " %*d | %s" (align_to + 1) i line
   in
   let process_file fd =
-    (* Printf.printf "Opened file: %s\n%!" pos.pos_fname; *)
-    (* let rec lines_seq channel () = *)
-    (*   match In_channel.input_line channel with *)
-    (*   | None -> None *)
-    (*   | Some line -> *)
-    (*   Printf.printf "Read line:\n%s\n%!" line; *)
-    (*   Some line *)
-    (* in *)
-    (* let lines = Seq.of_dispenser (lines_seq fd) *)
     let lines = Seq.of_dispenser (fun () -> In_channel.input_line fd)
       |> Seq.zip (Seq.ints 1 |> Seq.map Option.some)
       |> Seq.drop (pos.pos_start_line - 1 - options.context |> Int.max 0)

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -99,16 +99,29 @@ let to_string pos =
 
 module PrettyPrinting =
 struct
+  (** Options for underlining specified region *)
   type underline_options =
     | NoUnderline
+    (** Disable underlining *)
+
     | UnderlineBegining
+    (** Point to only beginning of region *)
+
     | UnderlineIfOneLine
+    (** Underline whole region, but only if specifies only one line *)
+
     | UnderlineAlways
+    (** Underline whole region *)
 
   type options = {
     context : int;
+    (** how many lines before and after region is to be printed *)
+
     underline : t -> underline_options;
+    (** function that depending on region will select underlining option *)
+
     add_line_numbers : bool;
+    (** should line numbers be added *)
   }
 
   let default_options = {
@@ -196,6 +209,3 @@ let get_text_range ?(options = PrettyPrinting.default_options) ?channel (pos : t
   in
   let pp_file_name = " -> " ^ pos.pos_fname ^ "\n" in
   Some (pp_file_name ^ file_chunk)
-
-
-


### PR DESCRIPTION
Added better position printing

Makes it so that instead of printing line and character number
we print piece of code specified by position of an error

Before:
```
$ dbl test/err/tc_0005_specialBinops.dbl
test/err/tc_0005_specialBinops.dbl:1:9-10: error: This expression has
type String, but an expression was expected of type Bool
test/err/tc_0005_specialBinops.dbl:2:9-10: error: This expression has
type String, but an expression was expected of type Bool
test/err/tc_0005_specialBinops.dbl:2:15-16: error: This expression has
type String, but an expression was expected of type Bool
test/err/tc_0005_specialBinops.dbl:2:21-22: error: This expression has
type String, but an expression was expected of type Bool
test/err/tc_0005_specialBinops.dbl:3:17: error: This expression has type
Int, but an expression was expected of type Bool
test/err/tc_0005_specialBinops.dbl:4:9-10: error: This expression has
type String, but an expression was expected of type Unit
```

Now:
```
$ dbl test/err/tc_0005_specialBinops.dbl
error: This expression has type String, but an expression was expected of type Bool
-> test/err/tc_0005_specialBinops.dbl
 1 | let _ = "" && True
   |         ^^
 2 | let _ = "" && "" || ""
 3 | let _ = True || 5
error: This expression has type String, but an expression was expected of type Bool
-> test/err/tc_0005_specialBinops.dbl
 1 | let _ = "" && True
 2 | let _ = "" && "" || ""
   |         ^^
 3 | let _ = True || 5
error: This expression has type String, but an expression was expected of type Bool
-> test/err/tc_0005_specialBinops.dbl
 1 | let _ = "" && True
 2 | let _ = "" && "" || ""
   |               ^^
 3 | let _ = True || 5
error: This expression has type String, but an expression was expected of type Bool
-> test/err/tc_0005_specialBinops.dbl
 1 | let _ = "" && True
 2 | let _ = "" && "" || ""
   |                     ^^
 3 | let _ = True || 5
error: This expression has type Int, but an expression was expected of type Bool
-> test/err/tc_0005_specialBinops.dbl
 2 | let _ = "" && "" || ""
 3 | let _ = True || 5
   |                 ^
 4 | let _ = ""; 5
error: This expression has type String, but an expression was expected of type Unit
-> test/err/tc_0005_specialBinops.dbl
 3 | let _ = True || 5
 4 | let _ = ""; 5
   |         ^^

```

I think this is a good quality of life improvement.
 