### PR TITLE
Rudimentary module patterns

### DIFF
--- a/src/DblParser/Raw.ml
+++ b/src/DblParser/Raw.ml
@@ -96,6 +96,9 @@ type ('tp, 'e) field_data =
   | FldNameAnnot of name * 'tp
     (** type-annotated implicit parameter *)
 
+  | FldModule of module_name
+    (** Module grouping named parameters *)
+
 (** Type expressions *)
 type type_expr = type_expr_data node
 and type_expr_data =

--- a/src/DblParser/YaccParser.mly
+++ b/src/DblParser/YaccParser.mly
@@ -490,6 +490,7 @@ field
 | name                  { make (FldName $1)           }
 | name EQ expr_no_comma { make (FldNameVal($1, $3))   }
 | name COLON ty_expr    { make (FldNameAnnot($1, $3)) }
+| KW_MODULE UID         { make (FldModule $2)         }
 ;
 
 field_list

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -155,6 +155,7 @@ and pattern_data =
   | PAnnot of pattern * scheme_expr
     (** Scheme annotation *)
 
+(** Set of named subpatterns of constructor *)
 and ctor_pattern_named =
   | CNParams of named_type_arg list * named_pattern list
     (** Named type parameters and named patterns of a constructor *)

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -149,12 +149,17 @@ and pattern_data =
   | PId of ident
     (** Pattern that binds an identifier*)
 
-  | PCtor of ctor_name path node * named_type_arg list *
-             named_pattern list * pattern list
+  | PCtor of ctor_name path node * ctor_pattern_named * pattern list
     (** ADT constructor pattern *)
 
   | PAnnot of pattern * scheme_expr
     (** Scheme annotation *)
+
+and ctor_pattern_named =
+  | CNParams of named_type_arg list * named_pattern list
+    (** Named type parameters and named patterns of a constructor *)
+  | CNModule of module_name
+    (** Bind all named parameters under the specified module name *)
 
 (** Pattern for named parameter *)
 and named_pattern = (name * pattern) node

--- a/test/ok/ok0108_modulePattern.fram
+++ b/test/ok/ok0108_modulePattern.fram
@@ -1,0 +1,35 @@
+data Bool = False | True
+
+data Ord = Lt | Eq | Gt
+
+data rec List A = [] | (::) of A, List A
+
+data Set Elem = Set of
+  { T
+  , empty : T
+  , method add : T -> Elem ->[] T
+  , method mem : T -> Elem ->[] Bool
+  }
+
+let add xs x = x :: xs
+
+let rec mem compare xs x =
+  match xs with
+  | []      => False
+  | y :: xs =>
+    match compare x y with
+    | Eq => True
+    | _  => mem compare xs x
+    end
+  end
+
+let make {Elem} (compare : Elem -> Elem ->[] Ord) =
+  Set { T = List Elem, empty = [], method add = add, method mem = mem compare }
+
+let compare (_ : Unit) (_ : Unit) = Eq
+
+let Set { module UnitSet } = make compare
+
+let m = UnitSet.empty.add ()
+
+let f () = m.mem ()


### PR DESCRIPTION
Adds support for pattern matching such as `let C { module M } = ...`. This hopefully brings us closer to making functors expressed as regular functions convenient to use. One limitation is that other fields can't be mixed with a module field, that is, the pattern `C { module M, x }` is currently invalid. Additionally, the `module M` syntax cannot be used to instantiate named parameters yet.

Removing the limitations would probably be best done alongside reworking how named parameter lists are treated.