### PR TITLE
Basic language server implementation

### DIFF
--- a/src/InterpLib/Error.ml
+++ b/src/InterpLib/Error.ml
@@ -17,7 +17,7 @@ let err_counter = ref 0
 let incr_error_counter () =
   err_counter := !err_counter + 1
 
-let report ?pos ~cls msg =
+let report_to_stderr ?pos ~cls msg =
   let name =
     match cls with
     | FatalError ->
@@ -35,6 +35,12 @@ let report ?pos ~cls msg =
   | Some pos ->
     Printf.eprintf "%s: %s: %s\n"
       (Position.to_string pos) name msg
+
+let report_impl = ref report_to_stderr
+
+let set_report_function f = report_impl := f
+
+let report ?pos ~cls msg = !report_impl ?pos ~cls msg
 
 let assert_no_error () =
   if !err_counter <> 0 then

--- a/src/InterpLib/Error.mli
+++ b/src/InterpLib/Error.mli
@@ -24,6 +24,10 @@ type error_class =
 (** Report the error *)
 val report : ?pos:Position.t -> cls:error_class -> string -> unit
 
+(* Used by the language server to intercept reports *)
+val set_report_function :
+  (?pos:Position.t -> cls:error_class -> string -> unit) -> unit
+
 (** Abort compilation if any error was reported. Should be called at the end
   of each phase. *)
 val assert_no_error : unit -> unit

--- a/src/Lsp/Connection.ml
+++ b/src/Lsp/Connection.ml
@@ -1,0 +1,59 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Base HTML-like protocol *)
+
+open In_channel
+open Out_channel
+
+exception Connection_error of string
+
+type headers =
+  { content_length: int option 
+  ; content_type: string option
+  }
+
+let parse_header headers line =
+  match String.split_on_char ':' line |> List.map String.trim with
+  | ["Content-Length"; value] -> begin
+    match int_of_string_opt value with
+    | None -> raise (Connection_error ("Invalid Content-Length value: " ^ line))
+    | Some len -> { headers with content_length = Some len }
+    end
+  | ["Content-Type"; value] -> { headers with content_type = Some value }
+  | _ -> raise (Connection_error ("Invalid header: " ^ line))
+
+let rec collect_headers (ic: in_channel) =
+  match input_line ic with
+  | None -> raise (Connection_error "Unexpected end of file")
+  | Some "\r" -> []
+  | Some line -> line :: collect_headers ic
+
+let receive_headers (ic: in_channel) =
+  let headers = collect_headers ic in
+  List.fold_left parse_header
+    { content_length = None; content_type = None }
+    headers
+
+let receive_body (ic: in_channel) len =
+  match really_input_string ic len with
+  | None -> raise (Connection_error "Unexpected end of file")
+  | Some body -> body  
+
+let receive_string (ic: in_channel) =
+  let headers = receive_headers ic in
+  match headers.content_length with
+  | None -> raise (Connection_error "Missing Content-Length header")
+  | Some len -> receive_body ic len
+
+let output_line (oc: out_channel) message =
+  let line = message ^ "\r\n" in
+  output_string oc line
+
+let send_string (oc: out_channel) message_string =
+  let length = String.length message_string in
+  output_line oc ("Content-Length: " ^ string_of_int length);
+  output_line oc "";
+  output_string oc message_string; flush oc
+

--- a/src/Lsp/Connection.ml
+++ b/src/Lsp/Connection.ml
@@ -10,7 +10,7 @@ open Out_channel
 exception Connection_error of string
 
 type headers =
-  { content_length: int option 
+  { content_length: int option
   ; content_type: string option
   }
 
@@ -39,7 +39,7 @@ let receive_headers (ic: in_channel) =
 let receive_body (ic: in_channel) len =
   match really_input_string ic len with
   | None -> raise (Connection_error "Unexpected end of file")
-  | Some body -> body  
+  | Some body -> body
 
 let receive_string (ic: in_channel) =
   let headers = receive_headers ic in

--- a/src/Lsp/Connection.mli
+++ b/src/Lsp/Connection.mli
@@ -1,0 +1,12 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Base HTML-like protocol *)
+
+exception Connection_error of string
+
+val receive_string : in_channel -> string
+
+val send_string : out_channel -> string -> unit
+

--- a/src/Lsp/JsonRpc.ml
+++ b/src/Lsp/JsonRpc.ml
@@ -35,17 +35,18 @@ let rec run (state : State.t) handle_request handle_notification =
       send_response state response;
       loop state
     | Some { id; method_name; params; _ } ->
-      try match id with
-      | None ->
-        let notification = parse_notification method_name params in
-        let state = handle_notification state notification in
-        loop state
-      | Some id ->
-        let request = parse_request method_name params in
-        let state, result_or_error = handle_request state request in
-        let response = make_response ~id result_or_error in
-        send_response state response;
-        loop state
+      try
+        match id with
+        | None ->
+          let notification = parse_notification method_name params in
+          let state = handle_notification state notification in
+          loop state
+        | Some id ->
+          let request = parse_request method_name params in
+          let state, result_or_error = handle_request state request in
+          let response = make_response ~id result_or_error in
+          send_response state response;
+          loop state
       with
       (* Only send error response if the message was a Request *)
       | Type_error _ when Option.is_some id ->

--- a/src/Lsp/JsonRpc.ml
+++ b/src/Lsp/JsonRpc.ml
@@ -29,7 +29,7 @@ let rec run (state : State.t) handle_request handle_notification =
 
     let message_raw = receive_string ic in
     match parse_message_option message_raw with
-    | None -> 
+    | None ->
       let response = make_response
         (make_response_error ~code:ParseError ~message:"Parse error" ()) in
       send_response state response;
@@ -49,8 +49,8 @@ let rec run (state : State.t) handle_request handle_notification =
       with
       (* Only send error response if the message was a Request *)
       | Type_error _ when Option.is_some id ->
-        let error = make_response_error 
-            ~code:InvalidParams 
+        let error = make_response_error
+            ~code:InvalidParams
             ~message:"Invalid params" () in
         let response = make_response ?id error in
         send_response state response;

--- a/src/Lsp/JsonRpc.ml
+++ b/src/Lsp/JsonRpc.ml
@@ -1,0 +1,62 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Main loop. Get message, handle it, send response. *)
+
+open Connection
+open Message
+
+let send_response state response =
+  let response_json = json_of_response response in
+  let response_string = Yojson.Safe.to_string response_json in
+  send_string (State.out_channel state) response_string
+
+let send_message state message =
+  let message_json = json_of_message message in
+  let message_string = Yojson.Safe.to_string message_json in
+  send_string (State.out_channel state) message_string
+
+let send_notification state notification =
+  let message = message_of_notification notification in
+  send_message state message
+
+let rec run (state : State.t) handle_request handle_notification =
+  let rec loop state =
+    let open Yojson.Safe.Util in
+
+    let ic = State.in_channel state in
+
+    let message_raw = receive_string ic in
+    match parse_message_option message_raw with
+    | None -> 
+      let response = make_response
+        (make_response_error ~code:ParseError ~message:"Parse error" ()) in
+      send_response state response;
+      loop state
+    | Some { id; method_name; params; _ } ->
+      try match id with
+      | None ->
+        let notification = parse_notification method_name params in
+        let state = handle_notification state notification in
+        loop state
+      | Some id ->
+        let request = parse_request method_name params in
+        let state, result_or_error = handle_request state request in
+        let response = make_response ~id result_or_error in
+        send_response state response;
+        loop state
+      with
+      (* Only send error response if the message was a Request *)
+      | Type_error _ when Option.is_some id ->
+        let error = make_response_error 
+            ~code:InvalidParams 
+            ~message:"Invalid params" () in
+        let response = make_response ?id error in
+        send_response state response;
+        loop state
+      (* The server MUST NOT reply to a Notification even in case of an error *)
+      | Type_error _ ->
+        loop state
+  in loop state
+

--- a/src/Lsp/JsonRpc.mli
+++ b/src/Lsp/JsonRpc.mli
@@ -1,0 +1,20 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Main loop. Get message, handle it, send response. *)
+
+open Message
+
+val send_response : State.t -> server_response -> unit
+
+val send_message : State.t -> message -> unit
+
+val send_notification : State.t -> server_notification -> unit
+
+val run :
+  State.t ->
+  (State.t -> client_request -> State.t * (server_result, response_error) Either.t) ->
+  (State.t -> client_notification -> State.t) ->
+  'bottom
+

--- a/src/Lsp/Message.ml
+++ b/src/Lsp/Message.ml
@@ -48,7 +48,7 @@ let json_of_range range =
     ("end", json_of_position range.end_);
   ]
 let range_of_pos (pos : Position.t) =
-  { 
+  {
     start = {
       line = pos.pos_start_line - 1;
       character = Position.start_column pos - 1
@@ -83,8 +83,8 @@ let to_hover_params json =
   let text_document =
     json |> member "textDocument" |> to_text_document_identifier in
   let position = json |> member "position" |> to_position in
-  let work_done_token = 
-    json |> member "workDoneToken" |> to_progress_token_option in 
+  let work_done_token =
+    json |> member "workDoneToken" |> to_progress_token_option in
   { text_document; position; work_done_token }
 
 type text_document_item = {
@@ -314,7 +314,7 @@ let json_of_markup_content content =
     ("kind", json_of_markup_kind content.kind);
     ("value", `String content.value);
   ]
-  
+
 type hover_result = {
   contents: markup_content;
   range: range option;
@@ -341,7 +341,7 @@ let json_of_id (id : _ Either.t) =
   match id with
   | Left id -> `Int id
   | Right id -> `String id
-  
+
 (* notification or request *)
 type message = {
   jsonrpc: string;
@@ -394,7 +394,7 @@ let json_of_error_code code =
   | InvalidParams -> `Int (-32602)
   | InternalError -> `Int (-32603)
   | ServerNotInitialized -> `Int (-32002)
-  
+
 type response_error = {
   code: error_code;
   message: string;

--- a/src/Lsp/Message.ml
+++ b/src/Lsp/Message.ml
@@ -1,0 +1,430 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** JSON <--> OCaml translation of messages *)
+
+open Yojson.Safe.Util
+
+let make_assoc xs = `Assoc (List.filter (fun (_, v) -> v <> `Null) xs)
+
+let json_of_option f option =
+  match option with
+  | None -> `Null
+  | Some x -> f x
+let json_of_int n = `Int n
+let json_of_string s = `String s
+let json_of_json json = json
+
+type position = {
+  line : int;
+  character : int;
+}
+let to_position json =
+  let line = json |> member "line" |> to_int in
+  let character = json |> member "character" |> to_int in
+  { line; character }
+let json_of_position position =
+  make_assoc [
+    ("line", `Int position.line);
+    ("character", `Int position.character);
+  ]
+
+type range = {
+  start : position;
+  end_ : position (* json key: end *);
+}
+let to_range json =
+  let start = json |> member "start" |> to_position in
+  let end_ = json |> member "end" |> to_position in
+  { start; end_ }
+let to_range_option json =
+  match json with
+  | `Null -> None
+  | _ -> Some (to_range json)
+let json_of_range range =
+  make_assoc [
+    ("start", json_of_position range.start);
+    ("end", json_of_position range.end_);
+  ]
+let range_of_pos (pos : Position.t) =
+  { 
+    start = {
+      line = pos.pos_start_line - 1;
+      character = Position.start_column pos - 1
+    };
+    end_ = {
+      line = pos.pos_end_line - 1;
+      character = Position.end_column pos
+    };
+  }
+
+type text_document_identifier = {
+  uri: string
+}
+let to_text_document_identifier json =
+  let uri = json |> member "uri" |> to_string in
+  { uri }
+
+type progress_token = (int, string) Either.t
+let to_progress_token_option json : _ Either.t option =
+  match json with
+  | `Null -> None
+  | `Int token -> Some (Left token)
+  | `String token -> Some (Right token)
+  | _ -> raise (Type_error ("invalid progress token type", json))
+
+type hover_params = {
+  text_document: text_document_identifier;
+  position: position;
+  work_done_token: progress_token option;
+}
+let to_hover_params json =
+  let text_document =
+    json |> member "textDocument" |> to_text_document_identifier in
+  let position = json |> member "position" |> to_position in
+  let work_done_token = 
+    json |> member "workDoneToken" |> to_progress_token_option in 
+  { text_document; position; work_done_token }
+
+type text_document_item = {
+  uri: string;
+  language_id: string;
+  version: int;
+  text: string
+}
+let to_text_document_item json =
+  let uri = json |> member "uri" |> to_string in
+  let language_id = json |> member "languageId" |> to_string in
+  let version = json |> member "version" |> to_int in
+  let text = json |> member "text" |> to_string in
+  { uri; language_id; version; text }
+
+type did_open_params = {
+  text_document: text_document_item
+}
+let to_did_open_params json =
+  let text_document =
+    json |> member "textDocument" |> to_text_document_item in
+  { text_document }
+
+type versioned_text_document_identifier = {
+  version: int;
+  uri: string
+}
+let to_versioned_text_document_identifier json =
+  let version = json |> member "version" |> to_int in
+  let uri = json |> member "uri" |> to_string in
+  { version; uri }
+
+type text_document_content_change_event = {
+  range: range option;
+  text: string
+}
+let to_text_document_content_change_event json =
+  let range = json |> member "range" |> to_range_option in
+  let text = json |> member "text" |> to_string in
+  { range; text }
+
+type did_change_params = {
+  text_document: versioned_text_document_identifier;
+  content_changes: text_document_content_change_event list;
+}
+let to_did_change_params json =
+  let text_document =
+    json |> member "textDocument"
+    |> to_versioned_text_document_identifier in
+  let content_changes = json |> member "contentChanges"
+    |> to_list |> List.map to_text_document_content_change_event in
+  { text_document; content_changes }
+
+type did_close_params = {
+  text_document: text_document_identifier
+}
+let to_did_close_params json =
+  let text_document =
+    json |> member "textDocument" |> to_text_document_identifier in
+  { text_document }
+
+type location = {
+  uri: string;
+  range: range;
+}
+let json_of_location loc =
+  make_assoc [
+    ("uri", `String loc.uri);
+    ("range", json_of_range loc.range);
+  ]
+
+type diagnostic_severity =
+  | Error (* 1 *)
+  | Warning (* 2 *)
+  | Information (* 3 *)
+  | Hint (* 4 *)
+let json_of_diagnostic_severity severity =
+  match severity with
+  | Error -> `Int 1
+  | Warning -> `Int 2
+  | Information -> `Int 3
+  | Hint -> `Int 4
+let diagnostic_severity_of_error_class cls : diagnostic_severity =
+  let open InterpLib.Error in
+  match cls with
+  | FatalError -> Error
+  | Error -> Error
+  | Warning -> Warning
+  | Note -> Information
+
+type diagnostic_tag =
+  | Unnecessary (* 1 *)
+  | Deprecated (* 2 *)
+let json_of_diagnostic_tag tag =
+  match tag with
+  | Unnecessary -> `Int 1
+  | Deprecated -> `Int 2
+
+type diagnostic_related_information = {
+  location: location;
+  message: string;
+}
+let json_of_diagnostic_related_information ri =
+  make_assoc [
+    ("location", json_of_location ri.location);
+    ("message", `String ri.message);
+  ]
+
+type code_description = {
+  href: string;
+}
+let json_of_code_description cd =
+  make_assoc [
+    ("href", `String cd.href);
+  ]
+
+type diagnostic = {
+  range: range;
+  severity: diagnostic_severity option;
+  code: (int, string) Either.t option;
+  code_description: code_description option;
+  source: string option;
+  message: string;
+  tags: diagnostic_tag option;
+  related_information: diagnostic_related_information list;
+  data: Yojson.Safe.t option;
+}
+let make_diagnostic ?severity ?code ?code_description ?source ?tags ?related_information ?data ~message ~range () =
+  {
+    range;
+    severity;
+    code;
+    code_description;
+    source;
+    message;
+    tags;
+    related_information = related_information |> Option.value ~default:[];
+    data;
+  }
+let json_of_diagnostic d =
+  let json_of_code (code : (int, string) Either.t) =
+    match code with
+    | Left n -> `Int n
+    | Right s -> `String s
+  in
+  make_assoc [
+    ("range", json_of_range d.range);
+    ("severity", json_of_option json_of_diagnostic_severity d.severity);
+    ("code", json_of_option json_of_code d.code);
+    ("codeDescription", json_of_option json_of_code_description d.code_description);
+    ("source", json_of_option json_of_string d.source);
+    ("message", `String d.message);
+    ("tags", json_of_option json_of_diagnostic_tag d.tags);
+    ("relatedInformation", `List (List.map json_of_diagnostic_related_information d.related_information));
+    ("data", json_of_option json_of_json d.data);
+  ]
+
+type publish_diagnostics_params = {
+  uri: string;
+  version: int option;
+  diagnostics: diagnostic list;
+}
+let make_publish_diagnostics_params ?version ~uri ~diagnostics () =
+  {
+    uri;
+    version;
+    diagnostics;
+  }
+let json_of_publish_diagnostics_params params =
+  make_assoc [
+    ("uri", `String params.uri);
+    ("version", json_of_option json_of_int params.version);
+    ("diagnostics", `List (List.map json_of_diagnostic params.diagnostics));
+  ]
+
+type client_request =
+  | Initialize (* TODO: of initialize_params *)
+  | Shutdown
+  | Hover of hover_params
+  | Unknown of string
+let parse_request method_name params =
+  match method_name with
+  | "initialize" -> Initialize
+  | "shutdown" -> Shutdown
+  | "textDocument/hover" -> Hover (to_hover_params params)
+  | _ -> Unknown method_name
+
+type client_notification =
+  | Initialized
+  | Exit
+  | DidOpen of did_open_params
+  | DidChange of did_change_params
+  | DidClose of did_close_params
+  | Unknown of string
+let parse_notification method_name params =
+  match method_name with
+  | "initialized" -> Initialized
+  | "exit" -> Exit
+  | "textDocument/didOpen" -> DidOpen (to_did_open_params params)
+  | "textDocument/didChange" -> DidChange (to_did_change_params params)
+  | "textDocument/didClose" -> DidClose (to_did_close_params params)
+  | _ -> Unknown method_name
+
+type server_notification =
+  | PublishDiagnostics of publish_diagnostics_params
+let method_name_of_notification notification =
+  match notification with
+  | PublishDiagnostics _ -> "textDocument/publishDiagnostics"
+let json_of_notification notification =
+  match notification with
+  | PublishDiagnostics params -> json_of_publish_diagnostics_params params
+
+type markup_kind =
+  | PlainText (* "plaintext" *)
+  | Markdown (* "markdown" *)
+let json_of_markup_kind kind =
+  match kind with
+  | PlainText -> `String "plaintext"
+  | Markdown -> `String "markdown"
+
+type markup_content = {
+  kind: markup_kind;
+  value: string;
+}
+let json_of_markup_content content =
+  make_assoc [
+    ("kind", json_of_markup_kind content.kind);
+    ("value", `String content.value);
+  ]
+  
+type hover_result = {
+  contents: markup_content;
+  range: range option;
+}
+let json_of_hover_result result =
+  make_assoc [
+    ("contents", json_of_markup_content result.contents);
+    ("range", json_of_option json_of_range result.range);
+  ]
+
+type initialize_result = Yojson.Safe.t
+type server_result =
+  | Initialize of initialize_result
+  | Shutdown
+  | Hover of hover_result option
+let json_of_server_result result =
+  match result with
+  | Initialize result -> result
+  | Shutdown -> `Null
+  | Hover result -> json_of_option json_of_hover_result result
+
+type id = (int, string) Either.t
+let json_of_id (id : _ Either.t) =
+  match id with
+  | Left id -> `Int id
+  | Right id -> `String id
+  
+(* notification or request *)
+type message = {
+  jsonrpc: string;
+  id: id option;
+  method_name : string (* json key: method *);
+  params: Yojson.Safe.t;
+}
+let make_message ?(jsonrpc="2.0") ?id ~method_name ~params () =
+  { jsonrpc; id; method_name; params }
+let parse_message_option message =
+  try
+    let json = Yojson.Safe.from_string message in
+    let jsonrpc = json |> member "jsonrpc" |> to_string in
+    let id : _ Either.t option =
+      match json |> member "id" with
+      | `Null -> None
+      | `Int id -> Some (Left id)
+      | `String id -> Some (Right id)
+      | _ -> raise (Type_error ("invalid id type", json))
+    in
+    let method_name = json |> member "method" |> to_string in
+    let params = json |> member "params" in
+    Some { jsonrpc; id; method_name; params }
+  with
+    | Type_error _ | Yojson.Json_error _ -> None
+let json_of_message message =
+  make_assoc [
+    ("jsonrpc", `String message.jsonrpc);
+    ("id", json_of_option json_of_id message.id);
+    ("method", `String message.method_name);
+    ("params", message.params)
+  ]
+let message_of_notification notification =
+  let method_name = method_name_of_notification notification in
+  let params = json_of_notification notification in
+  make_message ~method_name ~params ()
+
+type error_code =
+  | ParseError (* -32700 *)
+  | InvalidRequest (* -32600 *)
+  | MethodNotFound (* -32601 *)
+  | InvalidParams (* -32602 *)
+  | InternalError (* -32603 *)
+  | ServerNotInitialized (* -32002 *)
+let json_of_error_code code =
+  match code with
+  | ParseError -> `Int (-32700)
+  | InvalidRequest -> `Int (-32600)
+  | MethodNotFound -> `Int (-32601)
+  | InvalidParams -> `Int (-32602)
+  | InternalError -> `Int (-32603)
+  | ServerNotInitialized -> `Int (-32002)
+  
+type response_error = {
+  code: error_code;
+  message: string;
+  data: Yojson.Safe.t option;
+}
+let make_response_error ?data ~code ~message () =
+  Either.Right { code; message; data }
+let json_of_response_error error =
+  make_assoc [
+    ("code", json_of_error_code error.code);
+    ("message", `String error.message);
+    ("data", json_of_option json_of_json error.data);
+  ]
+
+type server_response = {
+  id: (int, string) Either.t option;
+  result_or_error: (server_result, response_error) Either.t;
+}
+let make_response ?id (result_or_error : _ Either.t) =
+  { id; result_or_error }
+let json_of_response response =
+  match response.result_or_error with
+  | Left result ->
+    (* Do not use make_assoc. id is required even if null *)
+    `Assoc [
+      ("id", json_of_option json_of_id response.id);
+      ("result", json_of_server_result result);
+    ]
+  | Right error ->
+    `Assoc [
+      ("id", json_of_option json_of_id response.id);
+      ("error", json_of_response_error error);
+    ]

--- a/src/Lsp/State.ml
+++ b/src/Lsp/State.ml
@@ -3,7 +3,7 @@
  *)
 
 (** Server state *)
- 
+
 module UriMap = Map.Make(String)
 
 type uri = string
@@ -23,7 +23,7 @@ type t = {
   documents: document UriMap.t
 }
 
-let create ~in_channel ~out_channel = 
+let create ~in_channel ~out_channel =
   {
     connection = { in_channel; out_channel };
     documents = UriMap.empty;
@@ -34,7 +34,7 @@ let in_channel { connection = { in_channel; _}; _ } = in_channel
 
 let open_document state uri =
   let real_path = Uri.to_path uri in
-  let content = 
+  let content =
     if Sys.file_exists real_path
     then
       let real_file = In_channel.open_text real_path in

--- a/src/Lsp/State.ml
+++ b/src/Lsp/State.ml
@@ -1,0 +1,72 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Server state *)
+ 
+module UriMap = Map.Make(String)
+
+type uri = string
+
+(* We keep the latest version of each document in a temp file *)
+type document = {
+  temp_path: string;
+}
+
+type connection = {
+  in_channel: in_channel;
+  out_channel: out_channel;
+}
+
+type t = {
+  connection: connection;
+  documents: document UriMap.t
+}
+
+let create ~in_channel ~out_channel = 
+  {
+    connection = { in_channel; out_channel };
+    documents = UriMap.empty;
+  }
+
+let out_channel { connection = { out_channel; _ }; _ } = out_channel
+let in_channel { connection = { in_channel; _}; _ } = in_channel
+
+let open_document state uri =
+  let real_path = Uri.to_path uri in
+  let content = 
+    if Sys.file_exists real_path
+    then
+      let real_file = In_channel.open_text real_path in
+      In_channel.input_all real_file
+    else "" in
+  let temp_path, oc = Filename.open_temp_file "" DblConfig.src_extension in
+  output_string oc content;
+  close_out oc;
+  let document = { temp_path } in
+  { state with documents = UriMap.add uri document state.documents }
+
+let update_document state uri new_content =
+  match UriMap.find_opt uri state.documents with
+  | None -> state
+  | Some doc ->
+    Out_channel.with_open_text doc.temp_path (fun oc ->
+      output_string oc new_content
+    ); state
+
+let close_document state uri =
+  match UriMap.find_opt uri state.documents with
+  | None -> state
+  | Some doc ->
+    Sys.remove doc.temp_path;
+    { state with documents = UriMap.remove uri state.documents }
+
+let close_all_documents state =
+  UriMap.iter (fun _ doc -> Sys.remove doc.temp_path) state.documents;
+  { state with documents = UriMap.empty }
+
+let get_document_path state uri =
+  match UriMap.find_opt uri state.documents with
+  | None -> Uri.to_path uri
+  | Some doc -> doc.temp_path
+

--- a/src/Lsp/State.mli
+++ b/src/Lsp/State.mli
@@ -1,0 +1,24 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Server state *)
+ 
+type t
+type uri = string
+
+val create : in_channel:in_channel -> out_channel:out_channel -> t
+
+val out_channel : t -> out_channel
+val in_channel : t -> in_channel
+
+val open_document : t -> uri -> t
+
+val update_document : t -> uri -> string -> t
+
+val close_document : t -> uri -> t
+
+val close_all_documents : t -> t
+
+val get_document_path : t -> uri -> string
+

--- a/src/Lsp/State.mli
+++ b/src/Lsp/State.mli
@@ -3,7 +3,7 @@
  *)
 
 (** Server state *)
- 
+
 type t
 type uri = string
 

--- a/src/Lsp/Uri.ml
+++ b/src/Lsp/Uri.ml
@@ -1,0 +1,9 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** URI helper functions *)
+
+let to_path uri =
+  String.sub uri (String.length "file://")
+    (String.length uri - String.length "file://")

--- a/src/Lsp/Uri.mli
+++ b/src/Lsp/Uri.mli
@@ -5,4 +5,3 @@
 (** URI helper functions *)
 
 val to_path : string -> string
-

--- a/src/Lsp/Uri.mli
+++ b/src/Lsp/Uri.mli
@@ -1,0 +1,8 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** URI helper functions *)
+
+val to_path : string -> string
+

--- a/src/Lsp/dblls.ml
+++ b/src/Lsp/dblls.ml
@@ -3,7 +3,7 @@
  *)
 
 (** Main module of the server. Handle messages from the client. *)
- 
+
 open Message
 open JsonRpc
 
@@ -27,7 +27,7 @@ let set_module_dirs ~fname () =
   DblConfig.lib_search_dirs := [DblConfig.stdlib_path];
   let cur_dir = Filename.dirname fname in
   DblConfig.local_search_dirs := [cur_dir]
-  
+
 let report file_path diags ?(pos : Position.t option) ~cls msg =
   let open InterpLib.Error in
   match pos with
@@ -50,7 +50,7 @@ let process_program state uri =
     |> ignore;
   with InterpLib.Error.Fatal_error -> ());
   let params =
-    make_publish_diagnostics_params 
+    make_publish_diagnostics_params
       ~uri ~diagnostics:(List.rev !diagnostics) () in
   JsonRpc.send_notification state (PublishDiagnostics params)
 
@@ -71,7 +71,7 @@ let handle_notification state notification =
   | DidClose params -> State.close_document state params.text_document.uri
   | Unknown _ -> state
 
-let handle_request state (request : client_request) 
+let handle_request state (request : client_request)
   : State.t * (server_result, response_error) Either.t =
   match request with
   | Initialize -> state, Left (Initialize initialize_params)
@@ -79,7 +79,7 @@ let handle_request state (request : client_request)
   | Hover params ->
     let error_message = "Method not supported: textDocument/hover" in
     state, make_response_error ~code:MethodNotFound ~message:error_message ()
-  | Unknown method_name -> 
+  | Unknown method_name ->
     let error_message = "Method not supported: " ^ method_name in
     state, make_response_error ~code:MethodNotFound ~message:error_message ()
 

--- a/src/Lsp/dblls.ml
+++ b/src/Lsp/dblls.ml
@@ -1,0 +1,88 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Main module of the server. Handle messages from the client. *)
+ 
+open Message
+open JsonRpc
+
+let initialize_params =
+  Yojson.Safe.from_string
+    {|
+      {
+        "capabilities": {
+          "textDocumentSync": {
+            "openClose": true,
+            "change": 1
+          }
+        },
+        "serverInfo": {
+          "name": "dblls"
+        }
+      }
+    |}
+
+let set_module_dirs ~fname () =
+  DblConfig.lib_search_dirs := [DblConfig.stdlib_path];
+  let cur_dir = Filename.dirname fname in
+  DblConfig.local_search_dirs := [cur_dir]
+  
+let report file_path diags ?(pos : Position.t option) ~cls msg =
+  let open InterpLib.Error in
+  match pos with
+  | None -> ()
+  | Some pos when pos.pos_fname = file_path ->
+    let severity = diagnostic_severity_of_error_class cls in
+    let range = range_of_pos pos in
+    let diag = make_diagnostic ~range ~severity ~message:msg () in
+    diags := diag :: !diags
+  | Some _ -> ()
+
+let process_program state uri =
+  let path = State.get_document_path state uri in
+  let diagnostics = ref [] in
+  InterpLib.Error.set_report_function (report path diagnostics);
+  set_module_dirs ~fname:(Uri.to_path uri) ();
+
+  (try DblParser.Main.parse_file ~use_prelude:true path
+    |> TypeInference.Main.tr_program
+    |> ignore;
+  with InterpLib.Error.Fatal_error -> ());
+  let params =
+    make_publish_diagnostics_params 
+      ~uri ~diagnostics:(List.rev !diagnostics) () in
+  JsonRpc.send_notification state (PublishDiagnostics params)
+
+let handle_notification state notification =
+  match notification with
+  | Initialized -> state
+  | Exit -> exit 0
+  | DidOpen params ->
+    let new_state = State.open_document state params.text_document.uri in
+    process_program new_state params.text_document.uri;
+    new_state
+  | DidChange params ->
+    let apply_content_change state change =
+      State.update_document state params.text_document.uri change.text in
+    let new_state = List.fold_left apply_content_change state params.content_changes in
+    process_program new_state params.text_document.uri;
+    new_state
+  | DidClose params -> State.close_document state params.text_document.uri
+  | Unknown _ -> state
+
+let handle_request state (request : client_request) 
+  : State.t * (server_result, response_error) Either.t =
+  match request with
+  | Initialize -> state, Left (Initialize initialize_params)
+  | Shutdown -> State.close_all_documents state, Left Shutdown
+  | Hover params ->
+    let error_message = "Method not supported: textDocument/hover" in
+    state, make_response_error ~code:MethodNotFound ~message:error_message ()
+  | Unknown method_name -> 
+    let error_message = "Method not supported: " ^ method_name in
+    state, make_response_error ~code:MethodNotFound ~message:error_message ()
+
+let _ =
+  let state = State.create ~in_channel:stdin ~out_channel:stdout in
+  JsonRpc.run state handle_request handle_notification

--- a/src/Lsp/dblls.ml
+++ b/src/Lsp/dblls.ml
@@ -45,10 +45,11 @@ let process_program state uri =
   InterpLib.Error.set_report_function (report path diagnostics);
   set_module_dirs ~fname:(Uri.to_path uri) ();
 
-  (try DblParser.Main.parse_file ~use_prelude:true path
+  begin try
+    DblParser.Main.parse_file ~use_prelude:true path
     |> TypeInference.Main.tr_program
     |> ignore;
-  with InterpLib.Error.Fatal_error -> ());
+  with InterpLib.Error.Fatal_error -> () end;
   let params =
     make_publish_diagnostics_params
       ~uri ~diagnostics:(List.rev !diagnostics) () in
@@ -65,7 +66,8 @@ let handle_notification state notification =
   | DidChange params ->
     let apply_content_change state change =
       State.update_document state params.text_document.uri change.text in
-    let new_state = List.fold_left apply_content_change state params.content_changes in
+    let new_state =
+      List.fold_left apply_content_change state params.content_changes in
     process_program new_state params.text_document.uri;
     new_state
   | DidClose params -> State.close_document state params.text_document.uri

--- a/src/Lsp/dune
+++ b/src/Lsp/dune
@@ -1,0 +1,5 @@
+(executable
+  (name dblls)
+  (modes byte exe)
+  (public_name dblls)
+  (libraries yojson dblParser interpLib typeInference toCore))

--- a/src/Lsp/dune
+++ b/src/Lsp/dune
@@ -1,5 +1,5 @@
 (executable
-  (name dblls)
+  (name framls)
   (modes byte exe)
-  (public_name dblls)
+  (public_name framls)
   (libraries yojson dblParser interpLib typeInference toCore))

--- a/src/Lsp/framls.ml
+++ b/src/Lsp/framls.ml
@@ -18,7 +18,7 @@ let initialize_params =
           }
         },
         "serverInfo": {
-          "name": "dblls"
+          "name": "framls"
         }
       }
     |}


### PR DESCRIPTION
Provides a basic language server with a diagnostics reporting feature (shows you errors in the code).
Available with a new `framls` executable.

The server intercepts error reports made by the typechecker so the result should be the same as running the file with `dbl`.

The code structure makes it easy to add new capabilities (but they will require changes in the dbl code).