### PR TITLE
Fix visibility of named patterns

### DIFF
--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -122,7 +122,7 @@ and type_arg_data =
   | TA_Effect
     (** Effect variable *)
 
-  | TA_Var of tvar * kind_expr
+  | TA_Var of is_public * tvar * kind_expr
     (** Type variable *)
   
   | TA_Wildcard

--- a/src/TypeInference/Type.ml
+++ b/src/TypeInference/Type.ml
@@ -132,7 +132,8 @@ and tr_effrow env eff =
 and tr_type_arg env (arg : S.type_arg) =
   match arg.data with
   | TA_Effect -> Env.add_the_effect ~pos:arg.pos env
-  | TA_Var(x, k) -> Env.add_tvar ~pos:arg.pos env x (tr_kind_expr k)
+  | TA_Var(public, x, k) ->
+    Env.add_tvar ~pos:arg.pos ~public env x (tr_kind_expr k)
   | TA_Wildcard -> Env.add_anon_tvar ~pos:arg.pos env (T.Kind.fresh_uvar ())
 
 and check_type_arg env (arg : S.type_arg) kind =
@@ -142,11 +143,11 @@ and check_type_arg env (arg : S.type_arg) kind =
     if not (Unification.unify_kind kind T.Kind.k_effect) then
       Error.fatal (Error.effect_arg_kind_mismatch ~pos:arg.pos kind);
     (env, x)
-  | TA_Var(x, k) -> 
+  | TA_Var(public, x, k) ->
     let kind_annot = tr_kind_expr k in
     if not (Unification.unify_kind kind_annot kind) then
       Error.fatal (Error.kind_annot_mismatch ~pos:arg.pos kind kind_annot);
-    Env.add_tvar ~pos:arg.pos env x kind
+    Env.add_tvar ~pos:arg.pos ~public env x kind
   | TA_Wildcard -> Env.add_anon_tvar ~pos:arg.pos env kind
 
 and tr_named_type_arg env (arg : S.named_type_arg) =
@@ -175,8 +176,8 @@ let check_type_alias_binder env (arg : S.type_arg) tp =
     if not (Unification.unify_kind kind T.Kind.k_effect) then
       Error.fatal (Error.effect_arg_kind_mismatch ~pos:arg.pos kind);
     Env.add_the_effect_alias env tp
-  | TA_Var(x, _) ->
-    Env.add_type_alias env x tp
+  | TA_Var(public, x, _) ->
+    Env.add_type_alias ~public env x tp
   | TA_Wildcard -> env
 
 let check_type_alias_binder_opt env arg_opt tp =

--- a/test/ok/ok0109_fieldPattern.fram
+++ b/test/ok/ok0109_fieldPattern.fram
@@ -1,0 +1,9 @@
+data T = C of { S, x : Int }
+
+module M
+  pub let C { S, x } = C { S = Unit, x = 42 }
+end
+
+let y = M.x
+
+let f (x : M.S) = x


### PR DESCRIPTION
Public visibility was not being properly propagated to named parameters in patterns. For example, the following code would fail.
```
data T = C of { S, x : Int }

module M
  pub let C { S, x } = C { S = Unit, x = 42 }
end

let y = M.x

let f (x : M.S) = x
```
Thanks @ppolesiuk for pointing out this problem.