### PR TITLE
Fix `!=` operator in lexer

### DIFF
--- a/src/DblParser/Lexer.mll
+++ b/src/DblParser/Lexer.mll
@@ -66,12 +66,12 @@ let tokenize_oper str =
     | ','                                           -> YaccParser.OP_30 str
     | '|' when (long && str.[1] = '|')              -> YaccParser.OP_40 str
     | '&' when (long && str.[1] = '&')              -> YaccParser.OP_50 str
-    | '=' | '<' | '>' | '|' | '&' | '$' | '#' | '?' -> YaccParser.OP_60 str
+    | '!' | '=' | '<' | '>' | '|' | '&' | '$' | '#' | '?' ->
+      YaccParser.OP_60 str
     | '@' | ':' | '^'                               -> YaccParser.OP_70 str
     | '+' | '-' | '~'                               -> YaccParser.OP_80 str
     | '*' when (long && str.[1] = '*')              -> YaccParser.OP_100 str
     | '*' | '/' | '%' | '.'                         -> YaccParser.OP_90 str
-    | '!'                                           -> YaccParser.OP_230 str
     | _ -> assert false
     end
 

--- a/src/DblParser/YaccParser.mly
+++ b/src/DblParser/YaccParser.mly
@@ -6,7 +6,6 @@
 
 %token<string> LID UID TLID
 %token<string> OP_0 OP_20 OP_30 OP_40 OP_50 OP_60 OP_70 OP_80 OP_90 OP_100
-%token<string> OP_230 
 %token<int> NUM
 %token<string> STR
 %token<char> CHR
@@ -133,10 +132,6 @@ uop_150
 : OP_80 { make $1 }
 ;
 
-uop_230
-: OP_230 { make $1 }
-;
-
 op
 : op_0   { $1 }
 | op_20  { $1 }
@@ -148,7 +143,6 @@ op
 | op_80  { $1 }
 | op_90  { $1 }
 | op_100 { $1 }
-| OP_230 { make $1 }
 ; 
 
 /* ========================================================================= */
@@ -408,11 +402,11 @@ expr_150
 ;
 
 expr_200
-: expr_230 { $1 }
+: expr_250 { $1 }
 | expr_250 expr_250_list1 { make (EApp($1, $2)) }
 | expr_200 GT_DOT lid expr_250_list { make (EMethodCall($1, $3, $4)) }
 | KW_EXTERN LID { make (EExtern $2) }
-| KW_PUB expr_230 { make (EPub $2) }
+| KW_PUB expr_250 { make (EPub $2) }
 ;
 
 expr_ctor
@@ -423,11 +417,6 @@ expr_select
 : UID DOT expr_ctor   { (NPName $1, $3) }
 | UID DOT expr_300    { (NPName $1, $3) }
 | UID DOT expr_select { let (p, e) = $3 in (NPSel($1, p), e) }
-
-expr_230
-: uop_230 expr_230 { make (EUOp($1, $2))}
-| expr_250 { $1 }
-;
 
 expr_250
 : expr_300    { $1 }


### PR DESCRIPTION
- `OP_230` and `expr_230` were removed
- Operators starting with `!` are treated as binary at level 50.

Rationale: The `OP_230` was introduced to have OCaml-like dereference operators (`!x`) on a very high precedence level. However, since we have methods in Fram, we can write `x.get`, which has high precedence, so unary dereference operator is not needed.

Fix #108 