### PR TITLE
Prelude split into multiple files

### DIFF
--- a/dune
+++ b/dune
@@ -4,4 +4,4 @@
 
 (install
  (section lib)
- (files (glob_files (lib/*.fram with_prefix stdlib))))
+ (files (glob_files_rec (lib/*.fram with_prefix stdlib))))

--- a/lib/Base/Bool.fram
+++ b/lib/Base/Bool.fram
@@ -1,0 +1,28 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+import open Types
+
+pub method toString = if self then "True" else "False"
+
+pub method neg =
+  if self then False else True
+
+pub method equal (oth : Bool) =
+  if self then oth else oth.neg
+
+pub method neq (oth : Bool) =
+  if self then oth.neg else oth
+
+pub method gt (oth : Bool) =
+  self && oth.neg
+
+pub method lt {self : Bool} oth =
+  self.neg && oth
+
+pub method ge (oth : Bool) =
+  self || oth.neg
+
+pub method le {self : Bool} oth =
+  self.neg || oth

--- a/lib/Base/Char.fram
+++ b/lib/Base/Char.fram
@@ -1,0 +1,17 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+import open /Base/Types
+
+pub method code {self : Char} = 
+  extern dbl_chrCode : Char -> Int
+
+pub method equal = (extern dbl_eqInt  : Char -> Char -> Bool) self
+pub method neq   = (extern dbl_neqInt : Char -> Char -> Bool) self
+pub method gt    = (extern dbl_gtInt  : Char -> Char -> Bool) self
+pub method lt    = (extern dbl_ltInt  : Char -> Char -> Bool) self
+pub method ge    = (extern dbl_geInt  : Char -> Char -> Bool) self
+pub method le    = (extern dbl_leInt  : Char -> Char -> Bool) self
+
+pub method toString = (extern dbl_chrToString : Char -> String) self

--- a/lib/Base/Char.fram
+++ b/lib/Base/Char.fram
@@ -4,8 +4,7 @@
 
 import open /Base/Types
 
-pub method code {self : Char} = 
-  extern dbl_chrCode : Char -> Int
+pub method code = (extern dbl_chrCode : Char -> Int) self
 
 pub method equal = (extern dbl_eqInt  : Char -> Char -> Bool) self
 pub method neq   = (extern dbl_neqInt : Char -> Char -> Bool) self

--- a/lib/Base/Int.fram
+++ b/lib/Base/Int.fram
@@ -26,6 +26,8 @@ pub method mod {`re : {type X} -> Unit ->[|_] X} (n : Int) =
   if n.equal 0 then `re ()
   else (extern dbl_modInt : Int -> Int -> Int) self n
 
+pub method neg {self : Int} = 0 - self
+
 pub method land = (extern dbl_andInt : Int -> Int -> Int) self
 pub method lor  = (extern dbl_orInt  : Int -> Int -> Int) self
 pub method lxor = (extern dbl_xorInt : Int -> Int -> Int) self

--- a/lib/Base/Int.fram
+++ b/lib/Base/Int.fram
@@ -1,0 +1,35 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+import open Types
+import open Operators
+
+pub method toString = (extern dbl_intToString : Int -> String) self
+
+pub method equal = (extern dbl_eqInt  : Int -> Int -> Bool) self
+pub method neq   = (extern dbl_neqInt : Int -> Int -> Bool) self
+pub method gt    = (extern dbl_gtInt  : Int -> Int -> Bool) self
+pub method lt    = (extern dbl_ltInt  : Int -> Int -> Bool) self
+pub method ge    = (extern dbl_geInt  : Int -> Int -> Bool) self
+pub method le    = (extern dbl_leInt  : Int -> Int -> Bool) self
+
+pub method add = (extern dbl_addInt : Int -> Int -> Int) self
+pub method sub = (extern dbl_subInt : Int -> Int -> Int) self
+pub method mul = (extern dbl_mulInt : Int -> Int -> Int) self
+
+pub method div {`re : {type X} -> Unit ->[|_] X} (n : Int) =
+  if n.equal 0 then `re ()
+  else (extern dbl_divInt : Int -> Int -> Int) self n
+
+pub method mod {`re : {type X} -> Unit ->[|_] X} (n : Int) =
+  if n.equal 0 then `re ()
+  else (extern dbl_modInt : Int -> Int -> Int) self n
+
+pub method land = (extern dbl_andInt : Int -> Int -> Int) self
+pub method lor  = (extern dbl_orInt  : Int -> Int -> Int) self
+pub method lxor = (extern dbl_xorInt : Int -> Int -> Int) self
+
+pub method shiftl  = (extern dbl_lslInt : Int -> Int -> Int) self
+pub method shiftr  = (extern dbl_lsrInt : Int -> Int -> Int) self
+pub method ashiftr = (extern dbl_asrInt : Int -> Int -> Int) self

--- a/lib/Base/Operators.fram
+++ b/lib/Base/Operators.fram
@@ -1,0 +1,27 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+pub method fn (- .) = neg
+
+pub method fn (+) = add
+pub method fn (-) = sub
+pub method fn (%) = mod
+pub method fn (/) = div
+pub method fn ( * ) = mul
+
+pub method fn (==) = equal
+pub method fn (!=) = neq
+pub method fn (>)  = gt
+pub method fn (>=) = ge
+pub method fn (<)  = lt
+pub method fn (<=) = le
+
+pub method fn (&&&) = land
+pub method fn (^^^) = lxor
+pub method fn (|||) = lor
+pub method fn (<<)  = shiftl
+pub method fn (>>)  = shiftr
+pub method fn (>>>) = ashiftr
+
+pub method fn (:=) = set

--- a/lib/Base/String.fram
+++ b/lib/Base/String.fram
@@ -1,0 +1,31 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+import open /Base/Types
+import open /Base/Operators
+import /Base/Int
+
+pub method add = (extern dbl_strCat : String -> String -> String) self
+
+pub method equal = (extern dbl_eqStr  : String -> String -> Bool) self
+pub method neq   = (extern dbl_neqStr : String -> String -> Bool) self
+pub method gt    = (extern dbl_gtStr  : String -> String -> Bool) self
+pub method lt    = (extern dbl_ltStr  : String -> String -> Bool) self
+pub method ge    = (extern dbl_geStr  : String -> String -> Bool) self
+pub method le    = (extern dbl_leStr  : String -> String -> Bool) self
+
+pub method length = (extern dbl_strLen : String -> Int) self
+pub method get {`re : {type X} -> Unit ->[|_] X, self : String} (n : Int) =
+  if n >= 0 && n < self.length then
+    (extern dbl_strGet : String -> Int -> Char) self n
+  else `re ()
+
+pub method toList {self : String} =
+  let getChar = extern dbl_strGet : String -> Int -> Char in
+  let rec iter (n : Int) acc = 
+    if n == 0 then 
+      acc
+    else 
+      iter (n - 1) (getChar self (n - 1) :: acc) 
+  in iter self.length []

--- a/lib/Base/Types.fram
+++ b/lib/Base/Types.fram
@@ -1,0 +1,13 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+pub data Bool = False | True
+
+pub data Option A = None | Some of A
+
+pub data rec List A = [] | (::) of A, List A
+
+pub data Pair X Y = (,) of X, Y
+
+pub data Either X Y = Left of X | Right of Y

--- a/lib/List.fram
+++ b/lib/List.fram
@@ -1,3 +1,7 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
 pub let isEmpty xs =
   match xs with
   | [] => True

--- a/lib/Prelude.fram
+++ b/lib/Prelude.fram
@@ -1,12 +1,16 @@
-pub data Bool = False | True
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
 
-pub data Option A = None | Some of A
+import /Base/Types
+import /Base/Operators
+import /Base/Bool
+import /Base/Int
+import /Base/Char
+import /Base/String
 
-pub data rec List A = [] | (::) of A, List A
-
-pub data Pair X Y = (,) of X, Y
-
-pub data Either X Y = Left of X | Right of Y
+pub open Types
+pub open Operators
 
 pub let id x = x
 
@@ -17,106 +21,13 @@ pub let snd (_, y) = y
 
 pub let not b = if b then False else True
 
-pub method toString = if self then "True" else "False"
-
-pub method fn (+) = add
-pub method fn (-) = sub
-pub method fn (%) = mod
-pub method fn (/) = div
-pub method fn ( * ) = mul
-
-pub method fn (==) = equal
-pub method fn (!=) = neq
-pub method fn (>)  = gt
-pub method fn (>=) = ge
-pub method fn (<)  = lt
-pub method fn (<=) = le
-
-pub method fn (&&&) = land
-pub method fn (^^^) = lxor
-pub method fn (|||) = lor
-pub method fn (<<)  = shiftl
-pub method fn (>>)  = shiftr
-pub method fn (>>>) = ashiftr
-
-pub method equal = (extern dbl_eqInt  : Int -> Int -> Bool) self
-pub method neq   = (extern dbl_neqInt : Int -> Int -> Bool) self
-pub method gt    = (extern dbl_gtInt  : Int -> Int -> Bool) self
-pub method lt    = (extern dbl_ltInt  : Int -> Int -> Bool) self
-pub method ge    = (extern dbl_geInt  : Int -> Int -> Bool) self
-pub method le    = (extern dbl_leInt  : Int -> Int -> Bool) self
-
-pub method toString = (extern dbl_intToString : Int -> String) self
-
-pub method add = (extern dbl_addInt : Int -> Int -> Int) self
-pub method sub = (extern dbl_subInt : Int -> Int -> Int) self
-pub method mul = (extern dbl_mulInt : Int -> Int -> Int) self
-
-pub method div {`re : {type X} -> Unit ->[|_] X} (n : Int) =
-  if n.equal 0 then `re ()
-  else (extern dbl_divInt : Int -> Int -> Int) self n
-
-pub method mod {`re : {type X} -> Unit ->[|_] X} (n : Int) =
-  if n.equal 0 then `re ()
-  else (extern dbl_modInt : Int -> Int -> Int) self n
-
-pub method land = (extern dbl_andInt : Int -> Int -> Int) self
-pub method lor  = (extern dbl_orInt  : Int -> Int -> Int) self
-pub method lxor = (extern dbl_xorInt : Int -> Int -> Int) self
-
-pub method shiftl  = (extern dbl_lslInt : Int -> Int -> Int) self
-pub method shiftr  = (extern dbl_lsrInt : Int -> Int -> Int) self
-pub method ashiftr = (extern dbl_asrInt : Int -> Int -> Int) self
-
-pub method add = (extern dbl_strCat : String -> String -> String) self
-
-pub method equal = (extern dbl_eqStr  : String -> String -> Bool) self
-pub method neq   = (extern dbl_neqStr : String -> String -> Bool) self
-pub method gt    = (extern dbl_gtStr  : String -> String -> Bool) self
-pub method lt    = (extern dbl_ltStr  : String -> String -> Bool) self
-pub method ge    = (extern dbl_geStr  : String -> String -> Bool) self
-pub method le    = (extern dbl_leStr  : String -> String -> Bool) self
-
-pub method length = (extern dbl_strLen : String -> Int) self
-pub method get {`re : {type X} -> Unit ->[|_] X, self : String} (n : Int) =
-  if n >= 0 && n < self.length then
-    (extern dbl_strGet : String -> Int -> Char) self n
-  else `re ()
-
-pub method makeString {`re : {type X} -> Unit ->[|_] X, self : String}
-    (n : Int) =
-  if n >= 0 && n < 256 then
-    (extern dbl_strMake : Int -> String) n
-  else `re ()
-
-pub method toList {self : String} =
-  let getChar = extern dbl_strGet : String -> Int -> Char in
-  let rec iter (n : Int) acc = 
-    if n == 0 then 
-      acc
-    else 
-      iter (n - 1) (getChar self (n - 1) :: acc) 
-  in iter self.length []
-
 pub let charListToStr = (extern dbl_chrListToStr : List Char -> String)
-
-pub method code {self : Char} = 
-  extern dbl_chrCode : Char -> Int
 
 pub let chr {`re : {type X} -> Unit ->[|_] X} (n : Int) = 
   if n >= 0 && n < 256 then
     (extern dbl_intToChr : Int -> Char) n
   else
     `re ()
-
-pub method equal = (extern dbl_eqInt  : Char -> Char -> Bool) self
-pub method neq   = (extern dbl_neqInt : Char -> Char -> Bool) self
-pub method gt    = (extern dbl_gtInt  : Char -> Char -> Bool) self
-pub method lt    = (extern dbl_ltInt  : Char -> Char -> Bool) self
-pub method ge    = (extern dbl_geInt  : Char -> Char -> Bool) self
-pub method le    = (extern dbl_leInt  : Char -> Char -> Bool) self
-
-pub method toString = (extern dbl_chrToString : Char -> String) self
 
 pub let printStrLn = extern dbl_printStrLn : String ->[IO] Unit
 pub let printStr   = extern dbl_printStr   : String ->[IO] Unit

--- a/src/Eval.ml
+++ b/src/Eval.ml
@@ -101,7 +101,6 @@ let extern_map =
     "dbl_leStr",   str_cmpop ( <= );
     "dbl_strLen",  str_fun (fun s -> VNum (String.length s));
     "dbl_strGet",  str_fun (fun s -> int_fun (fun n -> VNum (Char.code s.[n])));
-    "dbl_strMake", int_fun (fun n -> VStr (String.make 1 (Char.chr n)));
     "dbl_chrToString",  int_fun (fun c -> VStr (Char.escaped (Char.chr c)));
     "dbl_chrListToStr", list_chr_fun (fun xs -> VStr (List.to_seq xs |> String.of_seq));
     "dbl_chrCode",    int_fun (fun c -> VNum c);


### PR DESCRIPTION
Now the Prelude is split into several files. The two most notable files are `Base/Types` with some standard types and `Base/Operators` with some standard operators. Each of other files contains only methods that should be visible without importing anything. There is no `Base/List` file with standard methods on list. The user must import `List` module by himself.

Other minor changes are the following:
- Added LICENSE header in each library file
- Added comparison operators for Bool type
- Removed `makeString` method (function?), as it seemed broken.

Fixes #129 and #132 