### PR TITLE
Adding flag to disable printing of error context

### DIFF
--- a/src/DblConfig.ml
+++ b/src/DblConfig.ml
@@ -21,6 +21,8 @@ let local_mod_prefix = "Main"
 let lib_search_dirs   : string list ref = ref [ ]
 let local_search_dirs : string list ref = ref [ ]
 
+let display_error_context = ref true
+
 let print_colors_auto () =
   Unix.isatty Unix.stdout
 

--- a/src/InterpLib/Error.ml
+++ b/src/InterpLib/Error.ml
@@ -38,10 +38,14 @@ let report ?pos ~cls msg =
     | Note    -> "note", Color.Teal
   in
   let name = Color.color_string color name in
-  let text_range = Option.bind pos
-    (TextRangePrinting.get_text_range
-      ~repl_input:(Buffer.contents repl_input)
-      ~color) in
+  let text_range =
+    if !DblConfig.display_error_context
+    then Option.bind pos
+      (TextRangePrinting.get_text_range
+        ~repl_input:(Buffer.contents repl_input)
+        ~color)
+    else None
+  in
   match pos, text_range with
   | Some pos, None ->
     Printf.eprintf "%s: %s: %s\n"

--- a/src/InterpLib/TextRangePrinting.ml
+++ b/src/InterpLib/TextRangePrinting.ml
@@ -196,7 +196,9 @@ let get_text_from_file ~options ~color_printer pos =
 
 let get_text_range ?(options=default_options) ~repl_input ~color (pos : t) =
   let color_printer = color_string color in
-  if pos.pos_fname = "<stdin>" && repl_input <> "" then
-    get_text_from_repl ~options ~repl_input ~color_printer pos
-  else
-    get_text_from_file ~options ~color_printer pos
+  try
+    if pos.pos_fname = "<stdin>" && repl_input <> "" then
+      get_text_from_repl ~options ~repl_input ~color_printer pos
+    else
+      get_text_from_file ~options ~color_printer pos
+  with _ -> None

--- a/src/dbl.ml
+++ b/src/dbl.ml
@@ -47,7 +47,7 @@ let cmd_args_options = Arg.align
     Arg.String (fun p -> cli_local_search_dirs := p :: !cli_local_search_dirs),
     " Add a path to local search directories";
 
-    "--no-error-context",
+    "-no-error-context",
     Arg.Clear DblConfig.display_error_context,
     " Do not print piece of code with error, just filename:line:character";
 

--- a/src/dbl.ml
+++ b/src/dbl.ml
@@ -47,6 +47,10 @@ let cmd_args_options = Arg.align
     Arg.String (fun p -> cli_local_search_dirs := p :: !cli_local_search_dirs),
     " Add a path to local search directories";
 
+    "--no-error-context",
+    Arg.Clear DblConfig.display_error_context,
+    " Do not print piece of code with error, just filename:line:character";
+
     "-color",
     Arg.Symbol (
       [ "always"; "never"; "auto"; ],

--- a/test/test_suite
+++ b/test/test_suite
@@ -34,4 +34,4 @@ function simple_error_tests {
   done
 }
 
-run_with_flags simple_error_tests "-no-prelude -no-stdlib"
+run_with_flags simple_error_tests "-no-prelude -no-stdlib --no-error-context"

--- a/test/test_suite
+++ b/test/test_suite
@@ -34,4 +34,4 @@ function simple_error_tests {
   done
 }
 
-run_with_flags simple_error_tests "-no-prelude -no-stdlib --no-error-context"
+run_with_flags simple_error_tests "-no-prelude -no-stdlib -no-error-context"


### PR DESCRIPTION
Fixes #142

Also I added try...with segment in TextRangePrinting, because at this point we want to print error and it's location and if printing context fails we would rather see error's position without context, then information that printing context failed.