### PR TITLE
Changes to rec records

### DIFF
--- a/src/DblParser/Desugar.ml
+++ b/src/DblParser/Desugar.ml
@@ -765,6 +765,9 @@ and tr_def ?(public=false) (def : Raw.def) =
     let public = public || pub in
     [ make (DOpen(public, path)) ]
   | DRec(pub, defs) when List.for_all node_is_rec_data defs ->
+    (* This case is a quick fix to make most record accessors
+       not marked impure if they aren't. (Explained #160) *)
+    (* TODO: Remove when more robust solution is implemented *)
     let public = public || pub in
     let dds, accessors = tr_defs ~public defs
       |> List.partition node_is_data_def in

--- a/test/ok/ok0116_pureRecordAccessor.fram
+++ b/test/ok/ok0116_pureRecordAccessor.fram
@@ -1,0 +1,9 @@
+rec
+  data A = A | B
+  data Vec X = { x : X, y : X }
+end
+
+let checkPure (f : _ -> _) = ()
+
+let _ = checkPure (fn (c : Vec Unit) => c.x)
+let _ = checkPure (fn (c : Vec Unit) => c.y)


### PR DESCRIPTION
Changes mentioned in #149, they should make it so that most of the time accessors to record fields marked `data rec...` aren't unnecessarily marked as impure.
1. It's not gonna always work, by which i mean that sometimes they will be marked as impure even though they aren't, like in this code presented in original PR:
```
rec
  let foo (x : T) (n : Int) =
    if n == 0 then x
    else foo (x.x n) (n - 1)

  data T = { x : Int -> T }
end
```
2. It's gonna become obsolete if we decide to make non termination more precise.