### PR TITLE
Replace ocamlyacc with cpspg

### DIFF
--- a/src/DblParser/YaccParser.mly
+++ b/src/DblParser/YaccParser.mly
@@ -145,7 +145,7 @@ op
 | op_80  { $1 }
 | op_90  { $1 }
 | op_100 { $1 }
-; 
+;
 
 /* ========================================================================= */
 
@@ -391,7 +391,7 @@ expr_90
 ;
 
 // exp1 ** exp2
-expr_100 
+expr_100
 : expr_150 op_100 expr_100 { make (EBOp($1, $2, $3)) }
 | expr_150 { $1 }
 ;
@@ -417,6 +417,7 @@ expr_select
 : UID DOT expr_ctor   { (NPName $1, $3) }
 | UID DOT expr_300    { (NPName $1, $3) }
 | UID DOT expr_select { let (p, e) = $3 in (NPSel($1, p), e) }
+;
 
 expr_250
 : expr_300    { $1 }

--- a/src/DblParser/dune
+++ b/src/DblParser/dune
@@ -1,5 +1,10 @@
-(ocamlyacc (modules YaccParser))
 (ocamllex  (modules Lexer))
+;(ocamlyacc (modules YaccParser));
+
+(rule
+ (deps YaccParser.mly)
+ (target YaccParser.ml)
+ (action (run cpspg --compat -o %{target} %{deps})))
 
 (library
   (name dblParser)


### PR DESCRIPTION
This PR replaces ocamlyacc with adampsz/cpspg@67dfc0f3190a06363292c14c9315dd9c7dbc120b to check its compatibility and experiment with the new parser generator tool.

Building now requires `cpspg` to be in the path - it can be `dune build` and `dune install`-ed from adampsz/cpspg repo.