### PR TITLE
Line directives for the lexer

### DIFF
--- a/src/DblParser/Error.ml
+++ b/src/DblParser/Error.ml
@@ -50,6 +50,14 @@ let invalid_escape_code pos =
 let eof_in_string pos =
   (Some pos, "Unexpected end of file inside a string literal")
 
+let invalid_lexer_directive ?msg pos =
+  (Some pos,
+    Printf.sprintf
+      "Invalid lexer directive%s"
+        (match msg with
+        | None -> ""
+        | Some msg -> ": " ^ msg))
+
 let desugar_error pos =
   (Some pos, "Syntax error. This construction cannot be used in this context")
 

--- a/src/DblParser/Error.mli
+++ b/src/DblParser/Error.mli
@@ -30,6 +30,8 @@ val number_out_of_bounds : Position.t -> string -> t
 val invalid_escape_code : Position.t -> t
 val eof_in_string       : Position.t -> t
 
+val invalid_lexer_directive : ?msg:string -> Position.t -> t
+
 val desugar_error : Position.t -> t
 val reserved_binop_error : Position.t -> string -> t
 val disallowed_op_error : Position.t -> string -> t

--- a/test/err/lexer_0003_lexerDirective.fram
+++ b/test/err/lexer_0003_lexerDirective.fram
@@ -1,0 +1,3 @@
+#@ 123 foo
+in
+# @stderr:foo:123


### PR DESCRIPTION
This PR introduces line directives recognized by the lexer. For instance, in
```
#@ 123 foo.fram
let x = ... some error ...
```
the error will be reported in `foo.fram` at line 123.

Moreover, the lexer warns when it encounters other comments starting with `#@`. We might use such comments for other directives in the future.

Resolves #128