### PR TITLE
New Surface language

### DIFF
--- a/src/DblParser/Desugar.ml
+++ b/src/DblParser/Desugar.ml
@@ -5,7 +5,7 @@
 (** The first phase of desugaring and post-parsing *)
 
 open Lang.Surface
-
+(*
 (** Translation of the binary operator's name to the regular identifier. *)
 let tr_bop_id (op : string node) =
   if List.mem op.data ["&&"; "||"; ";"] then
@@ -863,6 +863,7 @@ and create_accessor_method ~public named_type_args pattern_gen scheme =
   | (NLabel | NImplicit _ | NMethod _ | NOptionalVar _), _ ->
     Error.warn (Error.ignored_field_in_record scheme.pos);
     None
-
+*)
 let tr_program (p : Raw.program) =
-  { p with data = tr_defs p.data }
+  failwith "Not implemented: Desugar.tr_program"
+  (*{ p with data = tr_defs p.data }*)

--- a/src/DblParser/Import.ml
+++ b/src/DblParser/Import.ml
@@ -137,6 +137,8 @@ let top_sort mods =
 (** Prepend a module alias based on the given import directive to the list
     of definitions, or open the module directly if no new name is specified. *)
 let add_import import defs =
+  failwith "Not implemented: DblParser.Import.add_import"
+(*
   let open Lang.Surface in
   let make data = { import with data } in
   let mod_id, new_name = import.data in
@@ -146,7 +148,7 @@ let add_import import defs =
     :: defs
   | None ->
     make (DOpen(false, NPName mod_id)) :: defs
-
+*)
 let add_imports = List.fold_right add_import
 
 let import_many imported imports =

--- a/src/DblParser/Main.ml
+++ b/src/DblParser/Main.ml
@@ -16,7 +16,7 @@ let make_nowhere data =
   { Lang.Surface.pos  = Position.nowhere
   ; Lang.Surface.data = data
   }
-
+(*
 let rec repl_seq imported () =
   InterpLib.Error.wrap_repl_cont (repl_seq_main imported) ()
 
@@ -57,11 +57,14 @@ and repl_seq_main imported () =
         lexbuf.Lexing.lex_start_p
         lexbuf.Lexing.lex_curr_p)
       (Lexing.lexeme lexbuf))
-
+*)
 let repl ~use_prelude =
+  failwith "Not implemented: DblParser.Main.repl"
+(*
   if use_prelude then
     let imported, prelude_defs = Import.import_prelude () in
     let repl_expr = make_nowhere (Lang.Surface.ERepl (repl_seq imported)) in
     make_nowhere (Lang.Surface.EDefs(prelude_defs, repl_expr))
   else
     make_nowhere (Lang.Surface.ERepl (repl_seq Import.import_set_empty))
+*)

--- a/src/DblParser/Raw.ml
+++ b/src/DblParser/Raw.ml
@@ -29,7 +29,7 @@ type var_id =
   | VIdUOp of op_name
 
 (** Name of a named parameter *)
-type name = Lang.Surface.name =
+type name =
   | NLabel
   | NVar         of var
   | NOptionalVar of var
@@ -48,7 +48,7 @@ type ctor_name =
 type module_name = string
 
 (** Module path to an identifier of type 'a *)
-type 'a path = 'a Lang.Surface.path =
+type 'a path =
   | NPName of 'a
   | NPSel  of module_name * 'a path
 
@@ -66,9 +66,6 @@ and kind_expr_data = Lang.Surface.kind_expr_data =
 
   | KEffect
     (** Effect kind*)
-
-  | KEffrow
-    (** Effect row kind *)
 
 (** Field of record-like, e.g., scheme name parameters, or explicit
   instantiation *)

--- a/src/DblParser/YaccParser.mly
+++ b/src/DblParser/YaccParser.mly
@@ -181,7 +181,6 @@ kind_expr_simple
 : BR_OPN kind_expr BR_CLS { make ($2).data }
 | KW_TYPE { make KType }
 | KW_EFFECT { make KEffect }
-| KW_EFFROW { make KEffrow }
 | UNDERSCORE { make KWildcard }
 ;
 

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -199,7 +199,7 @@ and named_pattern_data =
   | NP_Open
     (** Introduce everything into the environment *)
 
-(** Polymorphic expressions *)
+(** Polymorphic expressions, at the place of use. *)
 type poly_expr_use = poly_expr_use_data node
 and poly_expr_use_data =
   | EVar      of var path
@@ -211,7 +211,7 @@ and poly_expr_use_data =
   | EMethod   of expr * method_name
     (** Call of a method *)
 
-(** Polymorphic expression *)
+(** Polymorphic expressions, at the place of definition. *)
 and poly_expr_def = poly_expr_def_data node
 and poly_expr_def_data =
   | PE_Expr of expr

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -149,7 +149,7 @@ and scheme_arg_data =
   | SA_Val  of name * scheme_expr
     (** Value parameter *)
 
-(** Type formal parameter *)
+(** Formal type parameter *)
 and type_arg = type_arg_data node
 and type_arg_data =
   | TA_Var of tvar * kind_expr
@@ -158,6 +158,7 @@ and type_arg_data =
   | TA_Wildcard
     (** Wildcard *)
 
+(** Named formal type parameter *)
 and named_type_arg = (tname * type_arg) node
 
 (** Declaration of constructor of ADT *)

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -25,24 +25,23 @@ type method_name = string
 type module_name = string
 
 (** Module path to an identifier of type 'a *)
-type 'a path =
+type 'a path = 'a path_data node
+and 'a path_data =
   | NPName of 'a
-  | NPSel  of module_name * 'a path
+  | NPSel  of module_name path * 'a
 
 (** Extract the base name from a path *)
-let rec path_name = function
-  | NPName x    -> x
-  | NPSel(_, p) -> path_name p
+let path_name (path : _ path) =
+  match path.data with
+  | NPName x | NPSel(_, x) -> x
 
 (** Name of a named type parameter *)
 type tname =
   | TNAnon
-  | TNEffect
   | TNVar of tvar
 
 (** Name of a named parameter *)
 type name =
-  | NLabel
   | NVar         of var
   | NOptionalVar of var
   | NImplicit    of iname
@@ -53,10 +52,9 @@ type is_public = bool
 
 (** Identifier, i.e., object that can be bound in patterns *)
 type ident =
-  | IdLabel
-  | IdVar      of is_public * var
-  | IdImplicit of is_public * iname
-  | IdMethod   of is_public * method_name
+  | IdVar      of var
+  | IdImplicit of iname
+  | IdMethod   of method_name
     (** Methods must have an arrow type, where the argument type is a type
       of "self" variable. *)
 
@@ -75,9 +73,6 @@ and kind_expr_data =
   | KEffect
     (** Effect kind *)
 
-  | KEffrow
-    (** Effect row kind *)
-
 (** Type expressions *)
 type type_expr = type_expr_data node
 and type_expr_data =
@@ -87,21 +82,55 @@ and type_expr_data =
   | TVar of tvar path
     (** A (non-unification) type variable *)
 
+  | TEffect of type_expr list
+    (** Effect: list of simple effects *)
+
   | TPureArrow of scheme_expr * type_expr
     (** Pure function: a function without effects, that always terminates *)
 
   | TArrow of scheme_expr * type_expr * type_expr
     (** Effectful function: the last parameter is an effect *)
 
-  | TEffect of type_expr list * type_expr option
-    (** Effect: list of simple effect optionally closed by another effect *)
+  | THandler of (** First-class handler *)
+    { effect   : tvar;
+        (** Effect variable bound by this handler (it bound in [cap_type],
+          [in_type], and [in_eff] *)
+
+      cap_type : type_expr;
+        (** Type of a capability provided by this handler *)
+
+      in_type  : type_expr;
+        (** Inner type of a handler: a type of expression that can be run
+          inside this handler *)
+
+      in_eff   : type_expr;
+        (** Inner effect of a handler *)
+
+      out_type : type_expr;
+        (** Outer type of a handler: a type of the whole handler expression
+        *)
+
+      out_eff  : type_expr
+        (** Outer effect of a handler *)
+    }
+
+  | TE_Label of (** First-class label *)
+    { effect    : type_expr;
+        (** Effect of this label *)
+
+      delim_tp  : type_expr;
+        (** Type of the delimiter *)
+
+      delim_eff : type_expr
+        (** Effect of the delimiter *)
+    }
 
   | TApp of type_expr * type_expr
     (** Type application *)
 
 (** Type-scheme expressions *)
 and scheme_expr = {
-  sch_pos : Position.t;
+  sch_pos   : Position.t;
     (** Location of the scheme expression *)
 
   sch_targs : named_type_arg list;
@@ -120,9 +149,6 @@ and named_scheme = (name * scheme_expr) node
 (** Type formal parameter *)
 and type_arg = type_arg_data node
 and type_arg_data =
-  | TA_Effect
-    (** Effect variable *)
-
   | TA_Var of is_public * tvar * kind_expr
     (** Type variable *)
   
@@ -134,7 +160,6 @@ and named_type_arg = (tname * type_arg) node
 (** Declaration of constructor of ADT *)
 type ctor_decl = ctor_decl_data node
 and ctor_decl_data = {
-  cd_public      : is_public;
   cd_name        : ctor_name;
   cd_targs       : named_type_arg list;
   cd_named       : named_scheme list;
@@ -147,10 +172,10 @@ and pattern_data =
   | PWildcard
     (** Wildcard pattern -- it matches everything *)
 
-  | PId of ident
+  | PId of is_public * ident
     (** Pattern that binds an identifier*)
 
-  | PCtor of ctor_name path node * ctor_pattern_named * pattern list
+  | PCtor of ctor_name path * named_pattern list * pattern list
     (** ADT constructor pattern *)
 
   | PAnnot of pattern * scheme_expr
@@ -163,8 +188,17 @@ and ctor_pattern_named =
   | CNModule of is_public * module_name
     (** Bind all named parameters under the specified module name *)
 
-(** Pattern for named parameter *)
-and named_pattern = (name * pattern) node
+(** Pattern for a named parameter *)
+and named_pattern = named_pattern_data node
+and named_pattern_data =
+  | NP_Type   of named_type_arg
+    (** Type parameter *)
+  | NP_Val    of name * pattern
+    (** Value parameter *)
+  | NP_Module of module_name
+    (** Bind everything into a module *)
+  | NP_Open
+    (** Introduce everything into the environment *)
 
 (** Formal argument *)
 type arg =
@@ -176,9 +210,6 @@ type arg =
 
 (** Named formal argument *)
 type named_arg = (name * arg) node
-
-(** Explicit type instantiation *)
-type type_inst = (tname * type_expr) node
 
 (** Polymorphic expressions *)
 type poly_expr = poly_expr_data node
@@ -211,7 +242,7 @@ and expr_data =
   | EChr of char
     (** Char literal *)
 
-  | EPoly of poly_expr * type_inst list * inst list
+  | EPoly of poly_expr * inst list
     (** Polymorphic expression with partial explicit instantiation, possibly
       empty *)
 
@@ -219,7 +250,10 @@ and expr_data =
     (** Lambda abstraction *)
 
   | EApp  of expr * expr
-    (** Application *)
+    (** Application to an expression *)
+
+  | EAppFn of expr * named_pattern list * expr
+    (** Application to explicitly polymorphic function *)
 
   | EDefs of def list * expr
     (** Local definitions *)
@@ -231,9 +265,10 @@ and expr_data =
     (** First-class handler, with return and finally clauses. For each of these
       clause lists, empty list means the default identity clause *)
 
-  | EEffect of arg * expr
+  | EEffect of expr option * arg * expr
     (** Effectful operation. The only argument is a continuation. Other
-      arguments should be bound using regular lambda abstractions ([EFn]). *)
+      arguments should be bound using regular lambda abstractions ([EFn]).
+      The first parameter is an optional label. *)
 
   | EExtern of string
     (** Externally defined value *)
@@ -247,15 +282,24 @@ and expr_data =
       other have no effect. *)
 
 (** Explicit instantiation of named parameters in polymorphic expression *)
-and inst = (name * expr) node
+and inst = inst_data node
+and inst_data =
+  | IType   of tvar * type_expr
+    (** Explicit instantiation of a type variable *)
+  | IVal    of name * expr
+    (** Explicit instantiation of a value-level name *)
+  | IModule of module_name path
+    (** Explicit instantiation, that takes values from given module *)
+  | IOpen
+    (** Explicit instantiation, that takes values from the environment *)
 
 (** Local definitions *)
 and def = def_data node
 and def_data =
-  | DLetId of ident * expr
+  | DLetId of is_public * ident * expr
     (** Let definition: monomorphic or polymorphic, depending on effect *)
 
-  | DLetFun of ident * named_type_arg list * named_arg list * expr
+  | DLetFun of is_public * ident * named_type_arg list * named_arg list * expr
     (** Polymorphic function definition *)
 
   | DLetPat  of pattern * expr
@@ -264,24 +308,39 @@ and def_data =
   | DMethodFn of is_public * var * method_name
     (** Declaration of function that should be interpreted as a method *)
 
-  | DLabel   of type_arg option * pattern
-    (** Creating a new label. Optional type argument binds newly created
-      effect. *)
+  | DLabel   of type_arg * pattern
+    (** Creating a new label. *)
 
-  | DHandlePat of type_arg option * pattern * expr
+  | DHandlePat of pattern * type_arg * expr
     (** Effect handler combined with pattern matching. In
-      [DHandlePat(eff, pat, body)] the meaning of parameters is the following.
-      - [eff]  -- Optional name for the handled effect.
+      [DHandlePat(pat, eff, body)] the meaning of parameters is the following.
       - [pat]  -- Pattern matched against the effect capability.
+      - [eff]  -- A name for the handled effect.
       - [body] -- An expression that should evaluate to a first-class handler,
           providing the capability of the handled effect. *)
 
-  | DImplicit of iname * named_type_arg list * scheme_expr
-    (** Declaration of implicit. The second parameter is a list of types
-      that may differ between different uses of the implicit *)
+  | DTypeParam of tname * kind_expr
+    (** Declaration of type parameter *)
 
-  | DData of is_public * tvar * named_type_arg list * ctor_decl list
-    (** Definition of non-recursive ADT *)
+  | DValParam of name * scheme_expr
+    (** Declaration of value parameter *)
+
+  | DData of (** Definition of non-recursive ADT *)
+    { public_tp    : is_public;
+        (** A flag indicating that the type is public *)
+
+      public_ctors : is_public;
+        (** A flag indication that the constructors are visible *)
+
+      args         : named_type_arg list;
+        (** List of type parameters *)
+
+      ctors        : ctor_decl list
+        (** List of constructors *)
+    }
+
+  | DBlock of def list
+    (** Block of definitions that share parameter declarations *)
 
   | DRec of def list
     (** Mutually recursive definitions *)


### PR DESCRIPTION
This is my proposition of the new Surface language. The main changes includes:

- Changed representation of module paths: the order on a list is reversed. I think it would be more convenient during reporting good error messages).
- Removed `effect` type name. With the new effect inference it will be not needed.
- Removed `label` name. I think it should be changed to some implicit during desugaring phase.
- Removed `effrow` kind.
- Removed row from `TEffect` construct.
- Added abstract syntax for handler and label types.
- Changed the representation of constructor visibility. The flag is not attached to the constructor declaration, but to ADT definition (there are two flags there).
- Named patterns unifies type and value patters. There are two other constructors `NP_Module` and `NP_Open`.
- Explicit instantiation unifies type and value instantiations (similarly to named patterns).
- There are two constructors for an application: to an expression, and to a polymorphic function (e.g., `e1 (fn {x} => e2)`).
- `EEffect` construct takes optional label parameter.
- `is_public` flag is detached from `ident` type (I'm not sure, if it is the right choice).
- `DImplicit` is changed into more general `DTypeParam` and `DValParam`. There is no reminiscent of the second parameter of `DImplicit`, but it can be emulated via `DTypeParam` if necessary.
- Introduced `DBlock` definition.

I didn't touch the parser. It could be done in a separate PR.