### PR TITLE
Optional param annotations & module pattern visibility

### DIFF
--- a/src/DblParser/Desugar.ml
+++ b/src/DblParser/Desugar.ml
@@ -60,6 +60,12 @@ let annot_tp e tp =
     data = Raw.EAnnot(e, with_nowhere tp)
   }
 
+let scheme_wildcard pos =
+  { sch_pos  = pos;
+    sch_args = [];
+    sch_body = { pos; data = TWildcard }
+  }
+
 module RawTypes = struct
   let unit = Raw.TVar(with_nowhere (NPName "Unit"), None)
   let bool = Raw.TVar(with_nowhere (NPName "Bool"), None)
@@ -193,13 +199,7 @@ and tr_scheme_field (fld : Raw.ty_field) =
     let (y, k) = tr_type_var arg in
     make (SA_Type(TNVar x, y, k))
   | FldName n ->
-    let sch =
-      { sch_pos  = fld.pos;
-        sch_args = [];
-        sch_body = make TWildcard
-      }
-    in
-    make (SA_Val(n, sch))
+    make (SA_Val(n, scheme_wildcard fld.pos))
   | FldNameVal(n, tp) ->
     make (SA_Val(n, tr_scheme_expr tp))
   | FldNameAnnot _ | FldModule _ | FldOpen ->
@@ -343,6 +343,18 @@ let rec tr_pattern ~public (p : Raw.expr) =
   | EMethod _ | EExtern _ | EIf _ | EMethodCall _  ->
     Error.fatal (Error.desugar_error p.pos)
 
+(** Translate a pattern, separating out its annotation if present or creating
+  a wildcard annotation otherwise. *)
+and tr_annot_pattern ~public (p : Raw.expr) =
+  match p.data with
+  | EParen p       -> tr_annot_pattern ~public p
+  | EAnnot(p, sch) -> tr_pattern ~public p, tr_scheme_expr sch
+  | EWildcard | EUnit | EVar _ | EBOpID _ | EUOpID _ | EImplicit _ | ECtor _
+  | ENum _ | ENum64 _ | EStr _ | EChr _ | EFn _ | EApp _ | EDefs _ | EMatch _
+  | EHandler _ | EEffect _ | ERecord _ | EMethod _ | EMethodCall _ | EExtern _
+  | EIf _ | ESelect _ | EBOp _ | EUOp _ | EList _ | EPub _ ->
+    tr_pattern ~public p, scheme_wildcard p.pos
+
 and tr_named_pattern ~public (fld : Raw.field) =
   let make data = { fld with data = data } in
   match fld.data with
@@ -354,16 +366,17 @@ and tr_named_pattern ~public (fld : Raw.field) =
   | FldTypeVal(x, arg) ->
     make (NP_Type(public, make (TNVar x, tr_type_arg arg)))
   | FldName n ->
-    make (NP_Val(n, make (PId(public, ident_of_name n))))
+    make (NP_Val(n, make (PId(public, ident_of_name n)),
+                 scheme_wildcard fld.pos))
   | FldNameVal(n, p) ->
-    make (NP_Val(n, tr_pattern ~public p))
+    let (p, sch) = tr_annot_pattern ~public p in
+    make (NP_Val(n, p, sch))
   | FldNameAnnot(n, sch) ->
-    let arg =
-      make (PAnnot(make (PId(public, ident_of_name n)), tr_scheme_expr sch)) in
-    make (NP_Val(n, arg))
-  | FldModule { data = NPName name; _ } -> make (NP_Module name)
+    let p = make (PId(public, ident_of_name n)) in
+    make (NP_Val(n, p, tr_scheme_expr sch))
+  | FldModule { data = NPName name; _ } -> make (NP_Module(public, name))
   | FldModule _ -> Error.fatal (Error.desugar_error fld.pos)
-  | FldOpen     -> make NP_Open
+  | FldOpen     -> make (NP_Open public)
 
 (** Translate a parameter declaration *)
 let tr_param_decl (fld : Raw.field) =
@@ -376,13 +389,7 @@ let tr_param_decl (fld : Raw.field) =
     let k = Option.value ka ~default:(make KWildcard) in
     Either.Left (TNVar x, x, k)
   | FldName n ->
-    let sch =
-      { sch_pos   = fld.pos;
-        sch_args  = [];
-        sch_body  = make TWildcard
-      }
-    in
-    Either.Right (n, ident_of_name n, sch)
+    Either.Right (n, ident_of_name n, scheme_wildcard fld.pos)
   | FldNameAnnot(n, sch) ->
     Either.Right (n, ident_of_name n, tr_scheme_expr sch)
 
@@ -401,16 +408,17 @@ let tr_named_arg (fld : Raw.field) =
   | FldTypeVal(x, arg) ->
     make (NP_Type(false, make (TNVar x, tr_type_arg arg)))
   | FldName n ->
-    make (NP_Val(n, make (PId(false, ident_of_name n))))
+    make (NP_Val(n, make (PId(false, ident_of_name n)),
+                 scheme_wildcard fld.pos))
   | FldNameVal(n, e) ->
-    make (NP_Val(n, tr_pattern ~public:false e))
+    let (p, sch) = tr_annot_pattern ~public:false e in
+    make (NP_Val(n, p, sch))
   | FldNameAnnot(n, sch) ->
-    let arg =
-      make (PAnnot(make (PId(false, ident_of_name n)), tr_scheme_expr sch)) in
-    make (NP_Val(n, arg))
-  | FldModule { data = NPName name; _ } -> make (NP_Module name)
+    let p = make (PId(false, ident_of_name n)) in
+    make (NP_Val(n, p, tr_scheme_expr sch))
+  | FldModule { data = NPName name; _ } -> make (NP_Module(false, name))
   | FldModule _    -> Error.fatal (Error.desugar_error fld.pos)
-  | FldOpen        -> make NP_Open
+  | FldOpen        -> make (NP_Open false)
 
 (** Translate an expression as a let-pattern. *)
 let rec tr_let_pattern ~public (p : Raw.expr) =
@@ -823,9 +831,10 @@ and generate_accessor_method_pattern named_type_args type_name =
     } in
   (* function that generates pattern for accessing field *)
   let pattern_gen field =
+    let sch = scheme_wildcard Position.nowhere in
     make (PAnnot(make (PCtor(
       make (NPName type_name),
-      [ make (NP_Val(NVar field, make (PId(false, IdVar field)))) ],
+      [ make (NP_Val(NVar field, make (PId(false, IdVar field)), sch)) ],
       [])), type_annot))
   in
   new_named_type_args, pattern_gen

--- a/src/DblParser/Error.ml
+++ b/src/DblParser/Error.ml
@@ -72,9 +72,6 @@ let invalid_pattern_arg pos =
 let impure_scheme pos =
   (Some pos, "Syntax error. Type schemes must be pure")
 
-let anon_type_pattern pos =
-  (Some pos, "Syntax error. Anonymous types cannot be explicitly bound")
-
 let finally_before_return_clause pos =
   (Some pos, "Finally clause before return clause")
 

--- a/src/DblParser/Error.mli
+++ b/src/DblParser/Error.mli
@@ -35,7 +35,6 @@ val reserved_binop_error : Position.t -> string -> t
 val disallowed_op_error : Position.t -> string -> t
 val invalid_pattern_arg : Position.t -> t
 val impure_scheme : Position.t -> t
-val anon_type_pattern : Position.t -> t
 
 val finally_before_return_clause : Position.t -> t
 

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -190,7 +190,7 @@ and named_pattern_data =
   | NP_Type   of is_public * named_type_arg
     (** Type parameter *)
 
-  | NP_Val    of name * pattern * scheme_expr
+  | NP_Val    of name * pattern * scheme_expr option
     (** Value parameter.
       The scheme annotation is distinct from using the [PAnnot] constructor
       from [pattern] because it's treated differently for optional parameters.
@@ -323,7 +323,7 @@ and def_data =
   | DTypeParam of tname * tvar * kind_expr
     (** Declaration of type parameter *)
 
-  | DValParam of name * ident * scheme_expr
+  | DValParam of name * ident * scheme_expr option
     (** Declaration of value parameter *)
 
   | DData of (** Definition of non-recursive ADT *)

--- a/src/Lang/Surface.ml
+++ b/src/Lang/Surface.ml
@@ -190,13 +190,17 @@ and named_pattern_data =
   | NP_Type   of is_public * named_type_arg
     (** Type parameter *)
 
-  | NP_Val    of name * pattern
-    (** Value parameter *)
+  | NP_Val    of name * pattern * scheme_expr
+    (** Value parameter.
+      The scheme annotation is distinct from using the [PAnnot] constructor
+      from [pattern] because it's treated differently for optional parameters.
+      For example, [?x : T] should produce a variable [x : Option T], while
+      the pattern will be for the [Option T] type. *)
 
-  | NP_Module of module_name
+  | NP_Module of is_public * module_name
     (** Bind everything into a module *)
 
-  | NP_Open
+  | NP_Open   of is_public
     (** Introduce everything into the environment *)
 
 (** Polymorphic expressions, at the place of use. *)

--- a/src/TypeInference/Def.ml
+++ b/src/TypeInference/Def.ml
@@ -150,7 +150,16 @@ let check_def : type dir. tcfix:tcfix ->
 
   | DValParam(name, x, sch) ->
     let (sch_env, params) = ParameterEnv.begin_generalize env penv in
-    let sch = Type.tr_scheme sch_env sch in
+    let sch =
+      match sch with
+      | Some sch -> Type.tr_scheme sch_env sch
+      | None     ->
+        let tp =
+          { T.pos  = def.pos;
+            T.data = T.TE_Type (Env.fresh_uvar env T.Kind.k_type) }
+        in
+        T.SchemeExpr.of_type_expr tp
+    in
     let penv =
       ParameterEnv.end_generalize_declare ~pos params penv name x sch in
     cont.run env penv req

--- a/src/TypeInference/PartialEnv.ml
+++ b/src/TypeInference/PartialEnv.ml
@@ -355,23 +355,25 @@ let introduce_all_methods owner tab env =
 
 let introduce_module_types ~pos types env =
   List.fold_left
-    (fun env (name, x) -> Env.add_existing_tvar ~pos env name x)
+    (fun env (name, x) -> Env.add_existing_tvar ~pos ~public:true env name x)
     env types
 
 let introduce_module_vars vars env =
   List.fold_left
-    (fun env (name, x, sch) -> Env.add_existing_var env name x sch)
+    (fun env (name, x, sch) ->
+      Env.add_existing_var ~public:true env name x sch)
     env vars
 
 let introduce_module_implicits implicits env =
   List.fold_left
-    (fun env (name, x, sch) -> Env.add_existing_implicit env name x sch)
+    (fun env (name, x, sch) ->
+      Env.add_existing_implicit ~public:true env name x sch)
     env implicits
 
 let introduce_module_methods methods env =
   List.fold_left
     (fun env (owner, name, x, sch) ->
-      Env.add_existing_method env owner name x sch)
+      Env.add_existing_method ~public:true env owner name x sch)
     env methods
 
 let introduce_module name info env =

--- a/src/TypeInference/Pattern.ml
+++ b/src/TypeInference/Pattern.ml
@@ -302,46 +302,63 @@ and check_named_pattern env np tvars named =
       (env, PartialEnv.empty, T.Pure)
     end
 
-  | NP_Val((NVar _ | NOptionalVar _ | NImplicit _) as name, pat) ->
+  | NP_Val((NVar _ | NOptionalVar _ | NImplicit _) as name, pat, sch_expr) ->
     let name = tr_name name in
+    let sch = T.SchemeExpr.to_scheme (Type.tr_scheme env sch_expr) in
+    let sch =
+      match name with
+      | NOptionalVar _ ->
+        begin match T.Scheme.to_type sch with
+        | Some tp -> BuiltinTypes.mk_option_scheme tp
+        | None    ->
+          Error.fatal
+            (Error.polymorphic_optional_parameter ~pos:sch_expr.sch_pos)
+        end
+      | NVar _ | NImplicit _ -> sch
+      | NMethod _ -> assert false
+    in
     begin match select_named_pattern name named with
     | None ->
       Error.report (Error.unknown_named_pattern ~pos:np.pos name);
       (env, PartialEnv.empty, T.Pure)
 
-    | Some { pat = Some ppat; sch; _ } ->
+    | Some { pat = Some ppat; sch = sch'; _ } ->
       let ppos = ppat.pos in
       Error.report (Error.multiple_named_patterns ~pos:np.pos ~ppos name);
+      Error.check_unify_result ~pos:sch_expr.sch_pos
+        (Unification.subscheme env sch' sch)
+        ~on_error:(Error.pattern_annot_mismatch ~env sch' sch);
       let (penv, _, eff) = check_scheme env pat sch in
       (env, penv, eff)
 
-    | Some ({ pat = None; sch; _ } as np) ->
+    | Some ({ pat = None; sch = sch'; _ } as np) ->
+      Error.check_unify_result ~pos:sch_expr.sch_pos
+        (Unification.subscheme env sch' sch)
+        ~on_error:(Error.pattern_annot_mismatch ~env sch' sch);
       let (penv, pat, eff) = check_scheme env pat sch in
       np.pat <- Some pat;
       (env, penv, eff)
     end
 
-  | NP_Val(NMethod _, _) ->
+  | NP_Val(NMethod _, _, _) ->
     Error.report (Error.method_pattern_not_allowed ~pos:np.pos);
     (env, PartialEnv.empty, T.Pure)
 
-  | NP_Module modname ->
-    (* TODO: Public flag is missing *)
+  | NP_Module(public, modname) ->
     (* Since during type-checking of patterns we use the environment to
       store types, we don't need to add regular variables. *)
     let env = Env.enter_module env in
     let env = add_types_to_env ~pos:np.pos env tvars in
-    let env = Env.leave_module env ~public:false modname in
+    let env = Env.leave_module env ~public modname in
     let penv =
-      make_module_penv ~pos:np.pos ~public:false ~env modname tvars named in
+      make_module_penv ~pos:np.pos ~public ~env modname tvars named in
     (env, penv, T.Pure)
 
-  | NP_Open ->
-    (* TODO: Public flag is missing *)
+  | NP_Open public ->
     (* Since during type-checking of patterns we use the environment to
       store types, we don't need to add regular variables. *)
     let env = add_types_to_env ~pos:np.pos env tvars in
-    let penv = make_open_penv ~pos:np.pos ~public:false tvars named in
+    let penv = make_open_penv ~pos:np.pos ~public tvars named in
     (env, penv, T.Pure)
 
 (* ========================================================================= *)
@@ -388,15 +405,22 @@ let infer_named_pattern env (np : S.named_pattern) =
     let tvars = [(np.pos, tr_tname name, x)] in
     (env, penv, tvars, [], T.Pure)
 
-  | NP_Val(NOptionalVar x, pat) ->
-    let tp = Env.fresh_uvar env T.Kind.k_type in
-    let sch = BuiltinTypes.mk_option_scheme tp in
+  | NP_Val(NOptionalVar x, pat, sch_expr) ->
+    let sch = T.SchemeExpr.to_scheme (Type.tr_scheme env sch_expr) in
+    let sch =
+      match T.Scheme.to_type sch with
+      | Some tp -> BuiltinTypes.mk_option_scheme tp
+      | None    ->
+        Error.fatal
+          (Error.polymorphic_optional_parameter ~pos:sch_expr.sch_pos)
+    in
     let (penv, pat, eff) = check_scheme env pat sch in
     let arg = (np.pos, Uniqueness.UNOptionalVar x, pat, sch) in
     (env, penv, [], [arg], eff)
 
-  | NP_Val(name, pat) ->
-    let (penv, pat, sch, eff) = infer_scheme env pat in
+  | NP_Val(name, pat, sch_expr) ->
+    let sch = T.SchemeExpr.to_scheme (Type.tr_scheme env sch_expr) in
+    let (penv, pat, eff) = check_scheme env pat sch in
     let arg =
       match name with
       | NVar x -> (np.pos, Uniqueness.UNVar x, pat, sch)
@@ -408,7 +432,7 @@ let infer_named_pattern env (np : S.named_pattern) =
     in
     (env, penv, [], [arg], eff)
 
-  | NP_Open | NP_Module _ ->
+  | NP_Open _ | NP_Module _ ->
     Error.fatal (Error.open_pattern_not_allowed ~pos:np.pos)
 
 let infer_named_patterns env named_pats =

--- a/test/ok/ok0120_polyNamedPatternCheck.fram
+++ b/test/ok/ok0120_polyNamedPatternCheck.fram
@@ -1,0 +1,2 @@
+data T = T of {id : {X} -> X -> X}
+let foo (T {id}) = id id 42


### PR DESCRIPTION
Two Surface-related changes requested in #180.
* To deal with optional parameter annotations, the `NP_Val` constructor of named patterns now contains a scheme annotation which is treated in a special way.
* The `open` and `module M` named patterns now store their visibility. I also made a small change in `PartialEnv` because the contents of modules were introduced with the wrong visibility in `introduce_module`, causing the relevant test to fail.