### PR TITLE
Operations on scopes

### DIFF
--- a/src/Lang/Unif.mli
+++ b/src/Lang/Unif.mli
@@ -556,6 +556,9 @@ module TVar : sig
   (** Get the scope of a type variable *)
   val scope : tvar -> Scope.t
 
+  (** Check if a type variable can be used in a given scope *)
+  val in_scope : tvar -> Scope.t -> bool
+
   (** Finite sets of type variables *)
   module Set : Set.S with type elt = tvar
 
@@ -587,6 +590,9 @@ module UVar : sig
   (** Update the scope of a unification variable. Its scope is set to the
     intersection of its current scope and the given scope. *)
   val shrink_scope : t -> Scope.t -> unit
+
+  (** Check if a unification variable can be used in a given scope *)
+  val in_scope : t -> Scope.t -> bool
 
   (** Set of unification variables *)
   module Set : Set.S with type elt = t

--- a/src/Lang/UnifCommon/BuiltinType.ml
+++ b/src/Lang/UnifCommon/BuiltinType.ml
@@ -5,26 +5,26 @@
 (** Built-in type variable *)
 
 (** Int type *)
-let tv_int = TVar.fresh ~scope:Scope.root Kind.k_type
+let tv_int = TVar.fresh ~scope:Scope.initial Kind.k_type
 
 (** Int64 type *)
-let tv_int64 = TVar.fresh ~scope:Scope.root Kind.k_type
+let tv_int64 = TVar.fresh ~scope:Scope.initial Kind.k_type
 
 (** String type *)
-let tv_string = TVar.fresh ~scope:Scope.root Kind.k_type
+let tv_string = TVar.fresh ~scope:Scope.initial Kind.k_type
 
 (** Char type *)
-let tv_char = TVar.fresh ~scope:Scope.root Kind.k_type
+let tv_char = TVar.fresh ~scope:Scope.initial Kind.k_type
 
 (** Unit type *)
-let tv_unit = TVar.fresh ~scope:Scope.root Kind.k_type
+let tv_unit = TVar.fresh ~scope:Scope.initial Kind.k_type
 
 (** Option type *)
-let tv_option = TVar.fresh ~scope:Scope.root
+let tv_option = TVar.fresh ~scope:Scope.initial
   (Kind.k_arrow Kind.k_type Kind.k_type)
 
 (** IO effect *)
-let tv_io = TVar.fresh ~scope:Scope.root Kind.k_effect
+let tv_io = TVar.fresh ~scope:Scope.initial Kind.k_effect
 
 (** List of all built-in types together with their names *)
 let all =

--- a/src/Lang/UnifCommon/TVar.ml
+++ b/src/Lang/UnifCommon/TVar.ml
@@ -19,6 +19,7 @@ include Ordered
 let kind x = x.kind
 
 let fresh ?pp_uid ~scope kind =
+  assert (not (Scope.equal scope Scope.root));
   let uid = UID.fresh () in
   { uid    = uid;
     kind   = kind;
@@ -39,6 +40,8 @@ let uid x = x.uid
 let pp_uid x = x.pp_uid
 
 let scope x = x.scope
+
+let in_scope x scope = Scope.mem x.scope scope
 
 module Set = Set.Make(Ordered)
 module Map = Map.Make(Ordered)

--- a/src/Lang/UnifCommon/TVar.mli
+++ b/src/Lang/UnifCommon/TVar.mli
@@ -11,21 +11,39 @@ type t = private {
   scope  : Scope.t
 }
 
+(** Kind of a type variable *)
 val kind : t -> Kind.t
 
+(** Create fresh type variable of given kind. Optionally, a unique
+  identifier used by the pretty-printer can be provided. If omitted, it
+  will be the same as the freshly generated unique identifier of the
+  variable. *)
 val fresh : ?pp_uid:PPTree.uid -> scope:Scope.t -> Kind.t -> t
 
+(** Create a fresh type variable of the same kind and with the same
+  pretty-printer UID as the given one. *)
 val clone : scope:Scope.t -> t -> t
 
+(** Compare two type variables *)
 val compare : t -> t -> int
 
+(** Check type variables for equality *)
 val equal : t -> t -> bool
 
+(** Get the unique identifier *)
 val uid : t -> UID.t
 
+(** Get the unique identifier for pretty-printing *)
 val pp_uid : t -> PPTree.uid
 
+(** Get the scope of a type variable *)
 val scope : t -> Scope.t
 
+(** Check if a type variable can be used in a given scope *)
+val in_scope : t -> Scope.t -> bool
+
+(** Finite sets of type variables *)
 module Set : Set.S with  type elt = t
+
+(** Finite map from type variables *)
 module Map : Map.S with  type key = t

--- a/src/Lang/UnifPriv/Subst.ml
+++ b/src/Lang/UnifPriv/Subst.ml
@@ -56,7 +56,7 @@ let rec in_type_rec sub tp =
     begin match TVar.Map.find_opt x sub.sub with
     | Some tp -> tp
     | None ->
-      assert (Scope.mem (TVar.scope x) sub.scope);
+      assert (TVar.in_scope x sub.scope);
       tp
     end
   | TArrow(sch, tp2, eff) ->

--- a/src/Lang/UnifPriv/Type.ml
+++ b/src/Lang/UnifPriv/Type.ml
@@ -90,7 +90,7 @@ let scheme_uvars sch = collect_scheme_uvars sch UVar.Set.empty
 exception Escapes_scope of tvar
 
 let shrink_var_scope ~tvars ~scope x =
-  if Scope.mem (TVar.scope x) scope then ()
+  if TVar.in_scope x scope then ()
   else if TVar.Set.mem x tvars then ()
   else raise (Escapes_scope x)
 

--- a/src/Lang/UnifPriv/TypeBase.ml
+++ b/src/Lang/UnifPriv/TypeBase.ml
@@ -118,6 +118,9 @@ module UVar = struct
   let shrink_scope u scope =
     BRef.set u.scope (Scope.inter (BRef.get u.scope) scope)
 
+  let in_scope u scope =
+    Scope.mem (BRef.get u.scope) scope
+
   module Set = Set.Make(Ordered)
   module Map = Map.Make(Ordered)
 end

--- a/src/Lang/UnifPriv/TypeBase.mli
+++ b/src/Lang/UnifPriv/TypeBase.mli
@@ -100,6 +100,8 @@ module UVar : sig
     intersection of its current scope and the given scope. *)
   val shrink_scope : t -> Scope.t -> unit
 
+  val in_scope : t -> Scope.t -> bool
+
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
 end

--- a/src/TypeInference/Env.ml
+++ b/src/TypeInference/Env.ml
@@ -53,14 +53,14 @@ let empty =
     cur_module     = Module.empty;
     mod_stack      = MStack (StModule, Nil);
     pp_tree        = PPTree.empty;
-    scope          = Scope.root;
+    scope          = Scope.initial;
     param_env      = ParamEnv.empty
   }
 
 (* ========================================================================= *)
 
 let add_existing_tvar ?pos ?(public=false) (Env env) name x =
-  assert (Scope.mem (T.TVar.scope x) env.scope);
+  assert (T.TVar.in_scope x env.scope);
   Env { env with
     cur_module =
       Module.add_type_alias ~public env.cur_module name
@@ -224,7 +224,7 @@ let unit_adt =
   }
 
 let option_adt =
-  let a = T.TVar.fresh ~scope:(Scope.enter Scope.root) T.Kind.k_type in
+  let a = T.TVar.fresh ~scope:Scope.any T.Kind.k_type in
   { Module.adt_args  = [T.TNAnon, a];
     Module.adt_proof = T.PE_Option (T.Type.t_var a);
     Module.adt_ctors =

--- a/src/TypeInference/ParamGen.ml
+++ b/src/TypeInference/ParamGen.ml
@@ -20,7 +20,7 @@ let end_generalize_pure ~pos params uvs cs =
   (* Generalize all unification variables *)
   let scope = ParamEnv.scope params in
   let can_be_generalized u =
-    if Scope.mem (T.UVar.scope u) scope then false
+    if T.UVar.in_scope u scope then false
     else begin
       T.UVar.shrink_scope u scope;
       true

--- a/src/TypeInference/Type.ml
+++ b/src/TypeInference/Type.ml
@@ -179,7 +179,7 @@ let tr_named_type_arg penv (arg : S.named_type_arg) =
   | TA_Var(x, k) ->
     let kind = tr_kind k in
     (* It will be sustituted, so the scope is not important *)
-    let tvar = T.TVar.fresh ~scope:Scope.root kind in
+    let tvar = T.TVar.fresh ~scope:Scope.any kind in
     let penv = PartialEnv.add_anon_tvar ~pos penv tvar in
     let penv = PartialEnv.add_tvar_alias ~public:false ~pos penv x tvar in
     (penv, (pos, name, tvar))
@@ -187,7 +187,7 @@ let tr_named_type_arg penv (arg : S.named_type_arg) =
   | TA_Wildcard ->
     let kind = T.Kind.fresh_uvar () in
     (* It will be sustituted, so the scope is not important *)
-    let tvar = T.TVar.fresh ~scope:Scope.root kind in
+    let tvar = T.TVar.fresh ~scope:Scope.any kind in
     let penv = PartialEnv.add_anon_tvar ~pos penv tvar in
     (penv, (pos, name, tvar))
 

--- a/src/Utils/Scope.mli
+++ b/src/Utils/Scope.mli
@@ -10,17 +10,41 @@
 
 type t
 
-(** Initial scope. *)
+(** Root scope. It cannot contain any type variable. *)
 val root : t
+
+(** Initial scope. Builtin types are defined at this scope. *)
+val initial : t
+
+(** A scope that is not present in the tree rooted at the [root] scope.
+  The [parent], [enter], and [inter] functions should not be called on this
+  scope. *)
+val any : t
 
 (** Enter a new scope. The provided scope becomes the parent of the new one.
   *)
 val enter : t -> t
 
+(** Get the parent of a scope. Root scope has no parent. *)
+val parent : t -> t
+
 (** Intersection of two scopes. *)
 val inter : t -> t -> t
 
-(** Check if the first scope is a subset of the second one. In other words, if
-  a type variable marked as belonging to the first scope can be used in the
-  second scope. *)
+(** Check if two scopes are equal. *)
+val equal : t -> t -> bool
+
+(** Check if the first scope is a subset of the second one. In other words,
+  check if the first scope is a path starting at node that is an ancestor of
+  the second scope. *)
+val subset : t -> t -> bool
+
+(** Check if the first scope is a strict subset of the second one. Being a
+  strict subset doesn't mean that the scopes treated as sets are different:
+  the second scope may contain additional places of binding which don't
+  actually bind any type variable. *)
+val strict_subset : t -> t -> bool
+
+(** Check if a type variable marked as belonging to the first scope can be
+  used in the second scope. *)
 val mem : t -> t -> bool


### PR DESCRIPTION
- Renamed `root` to `initial` scope.
- Added `root` and `any` scopes. Root should not contain any type variables and is a parent of `initial`. This approach will be convenient in constraint solving: final solving of constraints will be just fixing scope of constraints to `root` and setting all remaining unification variables to pure.
- Added `parent`, `equal`, `subset`, and `strict_subset` operations. `subset` is basically the same as `mem`, but is used for different purposes, so more readable name will be convenient.
- `mem` function is not used directly, but wrapped around `TVar.in_scope` and `UVar.in_scope` functions.