### PR TITLE
Core language prepared for the new effect inference

### DIFF
--- a/src/Eval/Env.ml
+++ b/src/Eval/Env.ml
@@ -4,16 +4,25 @@
 
 open Value
 
-type t = value Var.Map.t ref
+type value_box = value option ref
 
-let empty = ref Var.Map.empty
+type t = value_box Var.Map.t
+
+let empty = Var.Map.empty
 
 let extend env x v =
-  ref (Var.Map.add x v !env)
+  Var.Map.add x (ref (Some v)) env
+
+let extend_box env x =
+  let box = ref None in
+  (Var.Map.add x box env, box)
+
+let update_box box v =
+  match !box with
+  | None -> box := Some v
+  | Some _ -> failwith "Runtime error: recursive value updated twice"
 
 let lookup env x =
-  Var.Map.find x !env
-
-let begin_fix  env = ref !env
-let update_fix env fix = fix := !env
-
+  match !(Var.Map.find x env) with
+  | Some v -> v
+  | None   -> failwith "Runtime error: non-productive recursive definition"

--- a/src/Eval/Env.mli
+++ b/src/Eval/Env.mli
@@ -2,16 +2,28 @@
  * See LICENSE for details.
  *)
 
+(** Environment of the interpreter *)
+
 open Value
 
 type t
 
+(** A box containing a value. The box might be empty in case of a recursive
+  definition. *)
+type value_box
+
+(** Empty environment *)
 val empty : t
 
+(** Extend the environment with a new binding *)
 val extend : t -> Var.t -> value -> t
 
+(** Extend the environment with an empty binding *)
+val extend_box : t -> Var.t -> t * value_box
+
+(** Update a contents of a box. It is an error to call this function on a
+  non-empty box. *)
+val update_box : value_box -> value -> unit
+
+(** Lookup a variable in the environment *)
 val lookup : t -> Var.t -> value
-
-val begin_fix  : t -> t
-
-val update_fix : t -> t -> unit

--- a/src/Eval/Eval.ml
+++ b/src/Eval/Eval.ml
@@ -47,13 +47,13 @@ let rec eval_expr env (e : Lang.Untyped.expr) cont =
     eval_expr env e1 (fun v ->
     eval_expr (Env.extend env x v) e2 cont)
   | ELetRec(rds, e2) ->
-    let env = Env.begin_fix env in
-    let (env, fxs) =
+    let (env, rds) =
       List.fold_left_map
-        (fun env (x, v) -> (Env.extend env x (eval_value env v), env))
+        (fun env (x, e) ->
+          let (env, box) = Env.extend_box env x in
+          (env, (box, e)))
         env rds in
-    List.iter (Env.update_fix env) fxs;
-    eval_expr env e2 cont
+    eval_rec_defs env rds (fun env -> eval_expr env e2 cont)
   | EApp(v1, v2) ->
     begin match eval_value env v1 with
     | VFn f -> f (eval_value env v2) cont
@@ -96,6 +96,14 @@ let rec eval_expr env (e : Lang.Untyped.expr) cont =
     eval_expr env e1 (fun v1 ->
       Printf.printf "= %s\n" (to_string v1);
       eval_expr env e2 cont)
+
+and eval_rec_defs env rds cont =
+  match rds with
+  | [] -> cont env
+  | (box, e) :: rds ->
+    eval_expr env e (fun v ->
+    Env.update_box box v;
+    eval_rec_defs env rds cont)
 
 and eval_value env (v : Lang.Untyped.value) =
   match v with

--- a/src/Lang/CorePriv/BuiltinType.ml
+++ b/src/Lang/CorePriv/BuiltinType.ml
@@ -18,6 +18,9 @@ let tv_string = TVar.fresh KType
 (** Unit type *)
 let tv_unit = TVar.fresh KType
 
+(** Option type *)
+let tv_option = TVar.fresh (KArrow(KType, KType))
+
 (** IO effect *)
 let tv_io = TVar.fresh KEffect
 
@@ -31,5 +34,6 @@ let all =
     "String", TVar.Ex tv_string;
     "Char",   TVar.Ex tv_int;
     "Unit",   TVar.Ex tv_unit;
+    "Option", TVar.Ex tv_option;
     "IO",     TVar.Ex tv_io;
     "#NTerm", TVar.Ex tv_nterm ]

--- a/src/Lang/CorePriv/ConstrSet.ml
+++ b/src/Lang/CorePriv/ConstrSet.ml
@@ -1,0 +1,35 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Set of constraints *)
+
+open TypeBase
+
+(** Effect constraints are represented as maps from effect variables to list
+  of their upper bounds. *)
+type t = effect list TVar.Map.t
+
+let empty = TVar.Map.empty
+
+let upper_bounds cset x =
+  match TVar.Map.find_opt x cset with
+  | None      -> []
+  | Some effs -> effs
+
+let rec add_simplify cset (eff1 : effect) eff2 =
+  match eff1 with
+  | TEffPure -> cset
+  | TEffJoin(effa, effb) ->
+    let cset = add_simplify cset effa eff2 in
+    add_simplify cset effb eff2
+  | TVar x ->
+    TVar.Map.add x (eff2 :: upper_bounds cset x) cset
+  | TApp _ ->
+    failwith "Internal error: TApp in effect"
+
+let add cset (eff1, eff2) =
+  add_simplify cset eff1 eff2
+
+let add_list cset cs =
+  List.fold_left add cset cs

--- a/src/Lang/CorePriv/ConstrSet.mli
+++ b/src/Lang/CorePriv/ConstrSet.mli
@@ -1,0 +1,18 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Set of constraints *)
+
+open TypeBase
+
+type t
+
+(** Empty set of constraints *)
+val empty : t
+
+(** Add a list of constraints to the set *)
+val add_list : t -> constr list -> t
+
+(** Get the list of upper bounds for a given effect variable *)
+val upper_bounds : t -> keffect tvar -> effect list

--- a/src/Lang/CorePriv/Effect.ml
+++ b/src/Lang/CorePriv/Effect.ml
@@ -16,9 +16,12 @@ let rec join eff1 eff2 =
   | TEffJoin(eff_a, eff_b), _ ->
     join eff_a (join eff_b eff2)
 
-  | (TVar _ | TApp _ | TUVar _), _ ->
-    if Type.simple_subeffect eff1 eff2 then eff2
+  | TVar x, _ ->
+    if Type.effect_mem x eff2 then eff2
     else TEffJoin(eff1, eff2)
+
+  | TApp _, _ ->
+    failwith "Internal error: TApp in effect"
 
 (** IO effect *)
 let io = TVar BuiltinType.tv_io
@@ -34,4 +37,7 @@ let rec is_pure eff =
   match eff with
   | TEffPure -> true
   | TEffJoin(eff1, eff2) -> is_pure eff1 && is_pure eff2
-  | TUVar _ | TVar _ | TApp _ -> false
+  | TVar _ -> false
+
+  | TApp _ ->
+    failwith "Internal error: TApp in effect"

--- a/src/Lang/CorePriv/SExprPrinter.ml
+++ b/src/Lang/CorePriv/SExprPrinter.ml
@@ -40,12 +40,13 @@ let tr_tvar_binder_ex (TVar.Ex x) =
 let rec tr_type : type k. k typ -> SExpr.t =
   fun tp ->
   match tp with
-  | TUVar (x, _) -> tr_uvar x
   | TEffPure -> List [ Sym "effect" ]
   | TEffJoin _ -> List (Sym "effect" :: tr_effect tp)
   | TVar x -> tr_tvar x
   | TArrow  _ -> List (tr_arrow tp)
   | TForall _ -> List (Sym "forall" :: tr_forall tp)
+  | TGuard(cs, tp) ->
+    List [Sym "guard"; List (List.map tr_constr cs); tr_type tp ]
   | TLabel lbl ->
     List
       [ Sym "label";
@@ -66,7 +67,7 @@ and tr_effect : effect -> SExpr.t list =
   | TEffJoin(eff1, eff2) ->
     tr_effect eff1 @ tr_effect eff2
   | TVar x -> [ tr_tvar x ]
-  | TUVar _ | TApp _ -> [ tr_type tp ]
+  | TApp _ -> [ tr_type tp ]
 
 and tr_arrow : ttype -> SExpr.t list =
   fun tp ->
@@ -76,7 +77,7 @@ and tr_arrow : ttype -> SExpr.t list =
   | TArrow(tp1, tp2, eff) ->
     [ tr_type tp1; Sym "->"; tr_type tp2; tr_type eff ]
 
-  | TUVar _ | TVar _ | TForall _ | TLabel _ | TData _ | TApp _ ->
+  | TVar _ | TForall _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
     [ Sym "->"; tr_type tp ]
 
 and tr_forall : ttype -> SExpr.t list =
@@ -85,7 +86,8 @@ and tr_forall : ttype -> SExpr.t list =
   | TForall(x, body) ->
     tr_tvar_binder x :: tr_forall body
 
-  | TUVar _ | TVar _ | TArrow _ | TLabel _ | TData _ | TApp _ -> [ tr_type tp ]
+  | TVar _ | TArrow _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
+    [ tr_type tp ]
 
 and tr_type_app : type k. k typ -> SExpr.t list -> SExpr.t =
   fun tp args ->
@@ -93,14 +95,17 @@ and tr_type_app : type k. k typ -> SExpr.t list -> SExpr.t =
   | TApp(tp1, tp2) ->
     tr_type_app tp1 (tr_type tp2 :: args)
 
-  | TUVar _ | TEffPure | TEffJoin _ | TVar _ | TArrow _ | TForall _ | TLabel _
-  | TData _ ->
+  | TEffPure | TEffJoin _ | TVar _ | TArrow _ | TForall _ | TGuard _
+  | TLabel _ | TData _ ->
     List (Sym "app" :: tr_type tp :: args)
 
 and tr_ctor_type { ctor_name; ctor_tvars; ctor_arg_types } =
   List (Sym ctor_name ::
     List (List.map tr_tvar_binder_ex ctor_tvars) ::
     List.map tr_type ctor_arg_types)
+
+and tr_constr (eff1, eff2) =
+  List [ tr_type eff1; Sym "<:"; tr_type eff2 ]
 
 let tr_type_ex (Type.Ex tp) =
   tr_type tp
@@ -127,12 +132,15 @@ let tr_data_def (dd : Syntax.data_def) =
 let rec tr_expr (e : Syntax.expr) =
   match e with
   | EValue v -> tr_value v
-  | ELet _ | ELetPure _ | ELetIrr _ | ELetRec _ | EData _ | EReset _ ->
+  | ELet _ | ELetPure _ | ELetIrr _ | ELetRec _ | ERecCtx _ | EData _
+  | EReset _ ->
     List (Sym "defs" :: tr_defs e)
   | EApp(v1, v2) ->
     List [ Sym "app"; tr_value v1; tr_value v2 ]
   | ETApp(v, tp) ->
     List [ Sym "tapp"; tr_value v; tr_type tp ]
+  | ECApp v ->
+    List [ Sym "capp"; tr_value v ]
   | EMatch(proof, v, cls, tp, eff) ->
     List [ Sym "match"; tr_expr proof; tr_value v;
       List (Sym "clauses" :: List.map tr_clause cls);
@@ -161,6 +169,8 @@ and tr_value (v : Syntax.value) =
     List (Sym "fn" :: List [ tr_var x; tr_type tp ] :: tr_defs body)
   | VTFun(x, body) ->
     List (Sym "tfun" :: tr_tvar_binder x :: tr_defs body)
+  | VCAbs(cs, body) ->
+    List (Sym "cabs" :: List (List.map tr_constr cs) :: tr_defs body)
   | VCtor(proof, n, tps, args) ->
     List (Sym "ctor" :: tr_expr proof :: Num n ::
       (List (List.map (fun (Type.Ex tp) -> tr_type tp) tps)) ::
@@ -178,6 +188,8 @@ and tr_defs (e : Syntax.expr) =
     List [Sym "let-irr"; tr_var x; tr_expr e1] :: tr_defs e2
   | ELetRec(rds, e2) ->
     List (Sym "let-rec" :: List.map tr_rec_def rds) :: tr_defs e2
+  | ERecCtx _ ->
+    List [Sym "rec-ctx"] :: tr_defs e
   | EData(dds, e2) ->
     List (Sym "data" :: List.map tr_data_def dds) :: tr_defs e2
   | EReset(v, tps, vs, body, x, ret) ->
@@ -189,12 +201,12 @@ and tr_defs (e : Syntax.expr) =
         tr_var x; tr_expr ret
       ] :: tr_defs body
 
-  | EValue _ | EApp _ | ETApp _ | EMatch _ | EShift _ | ERepl _
+  | EValue _ | EApp _ | ETApp _ | ECApp _ | EMatch _ | EShift _ | ERepl _
   | EReplExpr _ ->
     [ tr_expr e ]
 
 and tr_rec_def (x, tp, body) =
-  List [ tr_var x; tr_type tp; tr_value body ]
+  List [ tr_var x; tr_type tp; tr_expr body ]
 
 and tr_clause (c : Syntax.match_clause) =
   List (

--- a/src/Lang/CorePriv/Subst.ml
+++ b/src/Lang/CorePriv/Subst.ml
@@ -33,7 +33,7 @@ let add_tvars sub xs =
 let rec in_type_rec : type k. t -> k typ -> k typ =
   fun sub tp ->
   match tp with
-  | TUVar _ | TEffPure -> tp
+  | TEffPure -> tp
   | TEffJoin(eff1, eff2) ->
     TEffJoin(in_type_rec sub eff1, in_type_rec sub eff2)
   | TVar x ->
@@ -46,6 +46,8 @@ let rec in_type_rec : type k. t -> k typ -> k typ =
   | TForall(x, tp) ->
     let (sub, x) = add_tvar sub x in
     TForall(x, in_type_rec sub tp)
+  | TGuard(cs, tp) ->
+    TGuard(List.map (in_constr_rec sub) cs, in_type_rec sub tp)
   | TLabel lbl ->
     let effect = in_type_rec sub lbl.effect in
     let (sub, tvars) = add_tvars sub lbl.tvars in
@@ -60,6 +62,9 @@ let rec in_type_rec : type k. t -> k typ -> k typ =
       List.map (in_ctor_type_rec sub) ctors)
   | TApp(tp1, tp2) ->
     TApp(in_type_rec sub tp1, in_type_rec sub tp2)
+
+and in_constr_rec sub (eff1, eff2) =
+  (in_type_rec sub eff1, in_type_rec sub eff2)
 
 and in_ctor_type_rec sub ctor =
   let (sub, tvars) = add_tvars sub ctor.ctor_tvars in

--- a/src/Lang/CorePriv/Syntax.ml
+++ b/src/Lang/CorePriv/Syntax.ml
@@ -30,9 +30,11 @@ type expr =
   | ELet      of var * expr * expr
   | ELetPure  of var * expr * expr
   | ELetIrr   of var * expr * expr
-  | ELetRec   of (var * ttype * value) list * expr
+  | ELetRec   of (var * ttype * expr) list * expr
+  | ERecCtx   of expr
   | EApp      of value * value
   | ETApp      : value * 'k typ -> expr
+  | ECApp     of value
   | EData     of data_def list * expr
   | EMatch    of expr * value * match_clause list * ttype * effect
   | EShift    of value * TVar.ex list * var list * var * expr * ttype
@@ -47,6 +49,7 @@ and value =
   | VVar    of var
   | VFn     of var * ttype * expr
   | VTFun    : 'k tvar * expr -> value
+  | VCAbs   of constr list * expr
   | VCtor   of expr * int * Type.ex list * value list
   | VExtern of string * ttype
 

--- a/src/Lang/CorePriv/Type.ml
+++ b/src/Lang/CorePriv/Type.ml
@@ -9,15 +9,19 @@ open TypeBase
 (** Unit type *)
 let t_unit = TVar BuiltinType.tv_unit
 
+(** Option type *)
+let t_option arg =
+  TApp(TVar BuiltinType.tv_option, arg)
+
 (** Get the kind of given type *)
 let rec kind : type k. k typ -> k kind =
   function
-  | TUVar (_, k) -> k
   | TEffPure     -> KEffect
   | TEffJoin _   -> KEffect
   | TVar     x   -> TVar.kind x
   | TArrow   _   -> KType
   | TForall  _   -> KType
+  | TGuard   _   -> KType
   | TLabel  _    -> KType
   | TData    _   -> KType
   | TApp(tp, _) ->
@@ -29,40 +33,90 @@ let rec kind : type k. k typ -> k kind =
 let subst_type x stp tp =
   Subst.in_type (Subst.singleton x stp) tp
 
+(** Check if effect variable appears (syntactically) in an effect *)
+let rec effect_mem a (eff : effect) =
+  match eff with
+  | TEffPure -> false
+  | TEffJoin(effa, effb) -> effect_mem a effa || effect_mem a effb
+  | TVar b -> TVar.equal a b
+  | TApp _ ->
+    failwith "Internal error: TApp in effect"
+
+(** Check if one effect is a subeffect of another. In order to avoid infinite
+  loops, we keep track of the set of effect variables that we have already
+  visited. *)
+let rec subeffect_rec cset visited (eff1 : effect) eff2 =
+  match eff1 with
+  | TEffPure -> true
+  | TEffJoin(effa, effb) ->
+    subeffect_rec cset visited effa eff2 &&
+    subeffect_rec cset visited effb eff2
+  | TVar a ->
+    if TVar.Set.mem a visited then false
+    else
+      effect_mem a eff2 ||
+      let visited = TVar.Set.add a visited in
+      List.exists
+        (fun eff -> subeffect_rec cset visited eff eff2)
+        (ConstrSet.upper_bounds cset a)
+  | TApp _ ->
+    failwith "Internal error: TApp in effect"
+
+(** Check if one effect is a subeffect of another *)
+let subeffect cset eff1 eff2 =
+  subeffect_rec cset TVar.Set.empty eff1 eff2
+
+(** Check equality of effects *)
+let effect_equal cset eff1 eff2 =
+  subeffect cset eff1 eff2 && subeffect cset eff2 eff1
+
+(** Check if one set of constraints implies another *)
+let constrs_imply cset cs1 cs2 =
+  let cset = ConstrSet.add_list cset cs1 in
+  List.for_all (fun (eff1, eff2) -> subeffect cset eff1 eff2) cs2
+
+(** Check equality of constraint lists *)
+let rec constrs_equal cset cs1 cs2 =
+  constrs_imply cset cs1 cs2 && constrs_imply cset cs2 cs1
+
 (** Check equality of types *)
-let rec equal : type k. k typ -> k typ -> bool =
-  fun tp1 tp2 ->
+let rec equal : type k. ConstrSet.t -> k typ -> k typ -> bool =
+  fun cset tp1 tp2 ->
   match tp1, tp2 with
-  | TUVar(x,_), TUVar(y,_) -> UID.compare x y = 0
-  | _, TUVar _
-  | TUVar _, _ -> false
+  | TEffPure,   _ -> effect_equal cset tp1 tp2
+  | TEffJoin _, _ -> effect_equal cset tp1 tp2
+  | _, TEffPure   -> effect_equal cset tp1 tp2
+  | _, TEffJoin _ -> effect_equal cset tp1 tp2
 
-  | TEffPure,   _ -> effect_equal tp1 tp2
-  | TEffJoin _, _ -> effect_equal tp1 tp2
-  | _, TEffPure   -> effect_equal tp1 tp2
-  | _, TEffJoin _ -> effect_equal tp1 tp2
-
-  | TVar x, TVar y -> TVar.equal x y
+  | TVar x, TVar y ->
+    begin match TVar.kind x with
+    | KEffect -> effect_equal cset tp1 tp2
+    | _ -> TVar.equal x y
+    end
   | TVar _, _      -> false
 
   | TArrow(ta1, tb1, eff1), TArrow(ta2, tb2, eff2) ->
-    equal ta1 ta2 && equal tb1 tb2 && effect_equal eff1 eff2
+    equal cset ta1 ta2 && equal cset tb1 tb2 && effect_equal cset eff1 eff2
   | TArrow _, _ -> false
 
   | TForall(x1, tp1), TForall(x2, tp2) ->
     begin match Kind.equal (TVar.kind x1) (TVar.kind x2) with
     | Equal ->
-      if TVar.equal x1 x2 then equal tp1 tp2
+      if TVar.equal x1 x2 then equal cset tp1 tp2
       else begin
         let x = TVar.fresh (TVar.kind x1) in
-        equal (subst_type x1 (TVar x) tp1) (subst_type x2 (TVar x) tp2)
+        equal cset (subst_type x1 (TVar x) tp1) (subst_type x2 (TVar x) tp2)
       end
     | NotEqual -> false
     end
   | TForall _, _ -> false
 
+  | TGuard(cs1, tp1), TGuard(cs2, tp2) ->
+    constrs_equal cset cs1 cs2 && equal (ConstrSet.add_list cset cs1) tp1 tp2
+  | TGuard _, _ -> false
+
   | TLabel lbl1, TLabel lbl2 ->
-    effect_equal lbl1.effect lbl2.effect &&
+    effect_equal cset lbl1.effect lbl2.effect &&
     begin match
       tvars_binder_equal ~sub1:Subst.empty ~sub2:Subst.empty
         lbl1.tvars lbl2.tvars
@@ -72,32 +126,32 @@ let rec equal : type k. k typ -> k typ -> bool =
       List.length lbl1.val_types = List.length lbl2.val_types &&
       List.for_all2
         (fun tp1 tp2 ->
-          equal (Subst.in_type sub1 tp1) (Subst.in_type sub2 tp2))
+          equal cset (Subst.in_type sub1 tp1) (Subst.in_type sub2 tp2))
         lbl1.val_types lbl2.val_types &&
-      equal
+      equal cset
         (Subst.in_type sub1 lbl1.delim_tp)
         (Subst.in_type sub2 lbl2.delim_tp) &&
-      effect_equal
+      effect_equal cset
         (Subst.in_type sub1 lbl1.delim_eff)
         (Subst.in_type sub2 lbl2.delim_eff)
     end
   | TLabel _, _ -> false
 
   | TData(tp1, eff1, ctors1), TData(tp2, eff2, ctors2) ->
-    equal tp1 tp2 &&
-    equal eff1 eff2 &&
+    equal cset tp1 tp2 &&
+    equal cset eff1 eff2 &&
     List.length ctors1 = List.length ctors2 &&
-    List.for_all2 ctor_type_equal ctors1 ctors2
+    List.for_all2 (ctor_type_equal cset) ctors1 ctors2
   | TData _, _ -> false
 
   | TApp(tf1, ta1), TApp(tf2, ta2) ->
     begin match Kind.equal (kind ta1) (kind ta2) with
-    | Equal    -> equal tf1 tf2 && equal ta1 ta2
+    | Equal    -> equal cset tf1 tf2 && equal cset ta1 ta2
     | NotEqual -> false
     end
   | TApp _, _ -> false
 
-and ctor_type_equal { ctor_name; ctor_tvars; ctor_arg_types } ctor2 =
+and ctor_type_equal cset { ctor_name; ctor_tvars; ctor_arg_types } ctor2 =
   match
     tvars_binder_equal ~sub1:Subst.empty ~sub2:Subst.empty
       ctor_tvars ctor2.ctor_tvars
@@ -108,7 +162,7 @@ and ctor_type_equal { ctor_name; ctor_tvars; ctor_arg_types } ctor2 =
     List.length ctor_arg_types = List.length ctor2.ctor_arg_types &&
     List.for_all2
       (fun tp1 tp2 ->
-        equal (Subst.in_type sub1 tp1) (Subst.in_type sub2 tp2))
+        equal cset (Subst.in_type sub1 tp1) (Subst.in_type sub2 tp2))
       ctor_arg_types ctor2.ctor_arg_types
 
 and tvars_binder_equal ~sub1 ~sub2 xs1 xs2 =
@@ -125,69 +179,45 @@ and tvars_binder_equal ~sub1 ~sub2 xs1 xs2 =
     end
   | [], _ :: _ | _ :: _, [] -> None
 
-(** Check equality of effects *)
-and effect_equal : effect -> effect -> bool =
-  fun eff1 eff2 -> subeffect eff1 eff2 && subeffect eff2 eff1
-
-(** Check if one effect is a subeffect of another *)
-and subeffect eff1 eff2 =
-  match eff1 with
-  | TEffPure -> true
-  | TEffJoin(eff_a, eff_b) ->
-    subeffect eff_a eff2 && subeffect eff_b eff2
-  | TUVar _ | TVar _ | TApp _ -> simple_subeffect eff1 eff2
-
-(** Check if simple effect (different than pure and join) is a subeffect of
-  another effect *)
-and simple_subeffect eff1 eff2 =
-  match eff2 with
-  | TEffPure -> false
-  | TEffJoin(eff_a, eff_b) ->
-    simple_subeffect eff1 eff_a || simple_subeffect eff1 eff_b
-  | TUVar _ | TVar _ | TApp _ -> equal eff1 eff2
-
 (** Check if one type is a subtype of another *)
-let rec subtype tp1 tp2 =
+let rec subtype cset tp1 tp2 =
   match tp1, tp2 with
-  | TUVar _, TUVar _ -> equal tp1 tp2
-  | TUVar _, (TVar _ | TArrow _ | TForall _ | TLabel _ | TData _ | TApp _) ->
-    false
-
   | TVar x, TVar y -> x == y
-  | TVar _, (TUVar _ | TArrow _ | TForall _ | TLabel _ | TData _ | TApp _) ->
-    false
+  | TVar _, _ -> false
 
   | TArrow(atp1, vtp1, eff1), TArrow(atp2, vtp2, eff2) ->
-    subtype atp2 atp1 && subtype vtp1 vtp2 && subeffect eff1 eff2
-  | TArrow _, (TUVar _ | TVar _ | TForall _ | TLabel _ | TData _ | TApp _) ->
-    false
+    subtype cset atp2 atp1 && subtype cset vtp1 vtp2 &&
+    subeffect cset eff1 eff2
+  | TArrow _, _ -> false
 
   | TForall(x1, tp1), TForall(x2, tp2) ->
     (* TODO: it can be done better than O(n^2) time. *)
     begin match Kind.equal (TVar.kind x1) (TVar.kind x2) with
     | Equal ->
       let x = TVar (TVar.clone x1) in
-      subtype (subst_type x1 x tp1) (subst_type x2 x tp2)
+      subtype cset (subst_type x1 x tp1) (subst_type x2 x tp2)
     | NotEqual -> false
     end
-  | TForall _, (TUVar _ | TVar _ | TArrow _ | TLabel _ | TData _ | TApp _) ->
+  | TForall _, _ ->
     false
 
-  | TLabel _, TLabel _ -> equal tp1 tp2
-  | TLabel _, (TUVar _ | TVar _ | TArrow _ | TForall _ | TData _ | TApp _) ->
-    false
+  | TGuard(cs1, tp1), TGuard(cs2, tp2) ->
+    constrs_imply cset cs2 cs1 &&
+    subtype (ConstrSet.add_list cset cs2) tp1 tp2
+  | TGuard _, _ -> false
+
+  | TLabel _, TLabel _ -> equal cset tp1 tp2
+  | TLabel _, _ -> false
 
   | TData(tp1, eff1, ctors1), TData(tp2, eff2, ctors2) ->
-    equal tp1 tp2 &&
-    subeffect eff1 eff2 &&
+    equal cset tp1 tp2 &&
+    subeffect cset eff1 eff2 &&
     List.length ctors1 = List.length ctors2 &&
-    List.for_all2 ctor_type_equal ctors1 ctors2
-  | TData _, (TUVar _ | TVar _ | TArrow _ | TForall _ | TLabel _ | TApp _) ->
-    false
+    List.for_all2 (ctor_type_equal cset) ctors1 ctors2
+  | TData _, _ -> false
 
-  | TApp _, TApp _ -> equal tp1 tp2
-  | TApp _, (TUVar _ | TVar _ | TArrow _ | TForall _ | TLabel _ | TData _) ->
-    false
+  | TApp _, TApp _ -> equal cset tp1 tp2
+  | TApp _, _ -> false
 
 let rec forall_map f xs =
   match xs with
@@ -209,7 +239,7 @@ let add_tvars_to_scope tvs scope =
 let rec type_in_scope : type k. _ -> k typ -> k typ option =
   fun scope tp ->
   match tp with
-  | TUVar _ | TEffPure -> Some tp
+  | TEffPure -> Some tp
   | TEffJoin(eff1, eff2) ->
     begin match type_in_scope scope eff1, type_in_scope scope eff2 with
     | Some eff1, Some eff2 -> Some (TEffJoin(eff1, eff2))
@@ -231,6 +261,14 @@ let rec type_in_scope : type k. _ -> k typ -> k typ option =
     begin match type_in_scope (TVar.Set.add a scope) body with
     | Some body -> Some (TForall(a, body))
     | None      -> None
+    end
+  | TGuard(cs, tp) ->
+    begin match
+      forall_map (constr_in_scope scope) cs,
+      type_in_scope scope tp
+    with
+    | Some cs, Some tp -> Some (TGuard(cs, tp))
+    | _ -> None
     end
   | TLabel lbl ->
     let effect = type_in_scope scope lbl.effect in
@@ -261,6 +299,11 @@ let rec type_in_scope : type k. _ -> k typ -> k typ option =
     | _ -> None
     end
 
+and constr_in_scope scope (eff1, eff2) =
+  match type_in_scope scope eff1, type_in_scope scope eff2 with
+  | Some eff1, Some eff2 -> Some (eff1, eff2)
+  | _ -> None
+
 and ctor_type_in_scope scope ctor =
   let scope = add_tvars_to_scope ctor.ctor_tvars scope in
   match forall_map (type_in_scope scope) ctor.ctor_arg_types with
@@ -281,7 +324,7 @@ let supereffect_in_scope scope (eff : effect) =
   variables are members of given set ([scope]) *)
 let rec subeffect_in_scope scope (eff : effect) =
   match eff with
-  | TUVar _ | TEffPure -> eff
+  | TEffPure -> eff
   | TEffJoin(eff1, eff2) ->
     begin match
       subeffect_in_scope scope eff1,
@@ -295,16 +338,13 @@ let rec subeffect_in_scope scope (eff : effect) =
     if TVar.Set.mem a scope then eff
     else TEffPure
   | TApp _ ->
-    begin match type_in_scope scope eff with
-    | None     -> TEffPure
-    | Some eff -> eff
-    end
+    failwith "Internal error: TApp in effect"
 
 (** Tries to find a supertype of given type, such that all free type variables
   are members of given set ([scope]) *)
 let rec supertype_in_scope scope (tp : ttype) =
   match tp with
-  | TUVar _ | TVar _ | TLabel _ | TData _ | TApp _ -> type_in_scope scope tp
+  | TVar _ | TLabel _ | TData _ | TApp _ -> type_in_scope scope tp
   | TArrow(tp1, tp2, eff) ->
     begin match
       subtype_in_scope     scope tp1,
@@ -319,12 +359,20 @@ let rec supertype_in_scope scope (tp : ttype) =
     | Some body -> Some (TForall(a, body))
     | None      -> None
     end
+  | TGuard(cs, tp) ->
+    begin match
+      forall_map (constr_in_scope scope) cs,
+      supertype_in_scope scope tp
+    with
+    | Some cs, Some tp -> Some (TGuard(cs, tp))
+    | _ -> None
+    end
 
 (** Tries to find a subtype of given type, such that all free type variables
   are members of given set ([scope]) *)
 and subtype_in_scope scope (tp : ttype) =
   match tp with
-  | TUVar _ | TVar _ | TLabel _ | TApp _ -> type_in_scope scope tp
+  | TVar _ | TLabel _ | TApp _ -> type_in_scope scope tp
   | TArrow(tp1, tp2, eff) ->
     begin match
       supertype_in_scope scope tp1,
@@ -338,6 +386,14 @@ and subtype_in_scope scope (tp : ttype) =
     begin match subtype_in_scope (TVar.Set.add a scope) body with
     | Some body -> Some (TForall(a, body))
     | None      -> None
+    end
+  | TGuard(cs, tp) ->
+    begin match
+      forall_map (constr_in_scope scope) cs,
+      subtype_in_scope scope tp
+    with
+    | Some cs, Some tp -> Some (TGuard(cs, tp))
+    | _ -> None
     end
   | TData(tp, eff, ctors) ->
     begin match
@@ -354,8 +410,8 @@ and subtype_in_scope scope (tp : ttype) =
 let rec strictly_positive : type k. nonrec_scope:_ -> k typ -> bool =
   fun ~nonrec_scope tp ->
   match tp with
-  | TUVar _ | TVar _ | TEffPure -> true
-  | TLabel _ | TData _ ->
+  | TVar _ | TEffPure -> true
+  | TGuard _ | TLabel _ | TData _ ->
     begin match type_in_scope nonrec_scope tp with
     | Some _ -> true
     | None   -> false

--- a/src/Lang/CorePriv/TypeBase.ml
+++ b/src/Lang/CorePriv/TypeBase.ml
@@ -79,12 +79,12 @@ end
 type 'k tvar = 'k TVar.t
 
 type _ typ =
-  | TUVar    : UID.t * 'k kind -> 'k typ
   | TEffPure : keffect typ
   | TEffJoin : effect * effect -> keffect typ
   | TVar     : 'k tvar -> 'k typ
   | TArrow   : ttype * ttype * effect -> ktype typ
   | TForall  : 'k tvar * ttype -> ktype typ
+  | TGuard   : constr list * ttype -> ktype typ
   | TLabel   :
     { effect    : effect;
       tvars     : TVar.ex list;
@@ -97,6 +97,7 @@ type _ typ =
 
 and ttype  = ktype typ
 and effect = keffect typ
+and constr = keffect typ * keffect typ
 
 and ctor_type = {
   ctor_name      : string;

--- a/src/Lang/CorePriv/WellTypedInvariant.ml
+++ b/src/Lang/CorePriv/WellTypedInvariant.ml
@@ -40,6 +40,10 @@ module Env : sig
     irrelevant contexts. *)
   val add_irr_var : t -> var -> ttype -> t
 
+  (** Extend the environment with a recursively defined variable. It will be
+    available only after the call to [enter_rec_ctx]. *)
+  val add_rec_var : t -> var -> ttype -> t
+
   (** Extend environment with a type variable. It returns its refreshed
     version *)
   val add_tvar : t -> 'k tvar -> t * 'k tvar
@@ -47,9 +51,16 @@ module Env : sig
   (** Extend environment with a list of type variables. *)
   val add_tvars : t -> TVar.ex list -> t * TVar.ex list
 
+  (** Add a list of constraints to the environment. *)
+  val add_constrs : t -> constr list -> t
+
   (** Move to computationally irrelevant context, making all irrelevant
     variables available *)
   val irrelevant : t -> t
+
+  (** Move to recursive context, making all recursively defined variables
+    available *)
+  val enter_rec_ctx : t -> t
 
   (** Lookup for a type of given variable in the environment. *)
   val lookup_var : t -> var -> ttype
@@ -57,17 +68,27 @@ module Env : sig
   (** Lookup for a refreshed version of given type variable. *)
   val lookup_tvar : t -> 'k tvar -> 'k tvar
 
+  (** Get the current set of constraints. *)
+  val constr_set : t -> ConstrSet.t
+
   (** Get the current scope, i.e., set of available (refreshed) type
     variables. *)
   val scope : t -> TVar.Set.t
 end = struct
   module TMap = TVar.Map.Make(TVar)
 
+  type mode =
+    | Regular
+    | Irrelevant
+    | Recursive of int
+
   type t = {
-    var_map    : (bool * ttype) Var.Map.t;
+    var_map    : (mode * ttype) Var.Map.t;
     tvar_map   : TMap.t;
+    constr_set : ConstrSet.t;
     scope      : TVar.Set.t;
-    irrelevant : bool
+    irrelevant : bool;
+    rec_level  : int
   }
 
   let empty =
@@ -77,22 +98,29 @@ end = struct
         (fun tm (_, TVar.Ex x) -> TMap.add x x tm) 
         TMap.empty
         BuiltinType.all
+    ; constr_set = ConstrSet.empty
     ; scope      =
       List.fold_left
         (fun scope (_, TVar.Ex x) -> TVar.Set.add x scope) 
         TVar.Set.empty
         BuiltinType.all
     ; irrelevant = false
+    ; rec_level  = 0
     }
 
   let add_var env x tp =
     { env with
-      var_map = Var.Map.add x (false, tp) env.var_map
+      var_map = Var.Map.add x (Regular, tp) env.var_map
     }
 
   let add_irr_var env x tp =
     { env with
-      var_map = Var.Map.add x (true, tp) env.var_map
+      var_map = Var.Map.add x (Irrelevant, tp) env.var_map
+    }
+
+  let add_rec_var env x tp =
+    { env with
+      var_map = Var.Map.add x (Recursive env.rec_level, tp) env.var_map
     }
 
   let add_tvar env x =
@@ -109,14 +137,23 @@ end = struct
   let add_tvars env xs =
     List.fold_left_map add_tvar_ex env xs
 
+  let add_constrs env cs =
+    { env with constr_set = ConstrSet.add_list env.constr_set cs }
+
   let irrelevant env =
     { env with irrelevant = true }
 
+  let enter_rec_ctx env =
+    { env with rec_level = env.rec_level + 1 }
+
   let lookup_var env x =
     match Var.Map.find x env.var_map with
-    | (irr, _) when irr && not env.irrelevant ->
+    | (Irrelevant, _) when not env.irrelevant ->
       failwith
         "Internal error: using irrelevant variable in a relevant context."
+    | (Recursive lvl, _) when lvl >= env.rec_level ->
+      failwith
+        "Internal error: non-productive recursive definition"
     | (_, tp) -> tp
     | exception Not_found ->
       failwith "Internal error: unbound variable"
@@ -129,6 +166,8 @@ end = struct
         ~provided:(SExprPrinter.tr_tvar x)
         ()
 
+  let constr_set env = env.constr_set
+
   let scope env = env.scope
 end
 
@@ -137,9 +176,6 @@ end
 let rec tr_type : type k. Env.t -> k typ -> k typ =
   fun env tp ->
   match tp with
-  | TUVar _ ->
-    InterpLib.InternalError.report
-      ~reason:"Unsolved unification variables left." ();
   | TEffPure -> TEffPure
   | TEffJoin(eff1, eff2) ->
     TEffJoin(tr_type env eff1, tr_type env eff2)
@@ -149,6 +185,8 @@ let rec tr_type : type k. Env.t -> k typ -> k typ =
   | TForall(x, tp) ->
     let (env, x) = Env.add_tvar env x in
     TForall(x, tr_type env tp)
+  | TGuard(cs, tp) ->
+    TGuard(List.map (tr_constr env) cs, tr_type env tp)
   | TLabel lbl ->
     let effect = tr_type env lbl.effect in
     let (env, tvars) = Env.add_tvars env lbl.tvars in
@@ -162,6 +200,9 @@ let rec tr_type : type k. Env.t -> k typ -> k typ =
     TData(tr_type env tp, tr_type env eff, List.map (tr_ctor_type env) ctors)
   | TApp(tp1, tp2) ->
     TApp(tr_type env tp1, tr_type env tp2)
+
+and tr_constr env (eff1, eff2) =
+  (tr_type env eff1, tr_type env eff2)
 
 (** Ensure well-formedness of a constructor type and refresh its type
   variables according to the environment. *)
@@ -323,15 +364,15 @@ let rec infer_type_eff env e =
   | ELetRec(rds, e) ->
     let env = check_rec_defs env rds in
     infer_type_eff env e
+  | ERecCtx e ->
+    let (tp, eff) = infer_type_eff (Env.enter_rec_ctx env) e in
+    (tp, Effect.join eff Effect.nterm)
   | EApp(v1, v2) ->
     begin match infer_vtype env v1 with
     | TArrow(tp2, tp1, eff) ->
       check_vtype env v2 tp2;
       (tp1, eff)
-    | TUVar _ ->
-      InterpLib.InternalError.report
-        ~reason:"Unsolved unification variables left." ();
-    | TVar _ | TForall _ | TLabel _ | TData _ | TApp _ ->
+    | TVar _ | TForall _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
   | ETApp(v, tp) ->
@@ -342,10 +383,21 @@ let rec infer_type_eff env e =
       | Equal    -> (Type.subst_type x tp body, TEffPure)
       | NotEqual -> failwith "Internal kind error"
       end
-    | TUVar _ ->
-      InterpLib.InternalError.report
-        ~reason:"Unsolved unification variables left." ();
-    | TVar _ | TArrow _ | TLabel _ | TData _ | TApp _ ->
+    | TVar _ | TArrow _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
+      failwith "Internal type error"
+    end
+  | ECApp v ->
+    begin match infer_vtype env v with
+    | TGuard(cs, tp) ->
+      if
+        List.for_all
+          (fun (eff1, eff2) -> Type.subeffect (Env.constr_set env) eff1 eff2)
+          cs
+      then
+        (tp, TEffPure)
+      else
+        failwith "Internal type error"
+    | TVar _ | TArrow _ | TForall _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
 
@@ -395,10 +447,7 @@ let rec infer_type_eff env e =
       check_type_eff env body tp0 eff0;
       (tp, lbl.effect)
 
-    | TUVar _ ->
-      InterpLib.InternalError.report
-        ~reason:"Unsolved unification variables left." ();
-    | TVar _ | TArrow _ | TForall _ | TData _ | TApp _ ->
+    | TVar _ | TArrow _ | TForall _ | TGuard _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
 
@@ -418,10 +467,7 @@ let rec infer_type_eff env e =
       check_type_eff env ret delim_tp delim_eff;
       (delim_tp, delim_eff)
 
-    | TUVar _ ->
-      InterpLib.InternalError.report
-        ~reason:"Unsolved unification variables left." ();
-    | TVar _ | TArrow _ | TForall _ | TData _ | TApp _ ->
+    | TVar _ | TArrow _ | TForall _ | TGuard _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
 
@@ -449,6 +495,10 @@ and infer_vtype env v =
   | VTFun(x, body) ->
     let (env, x) = Env.add_tvar env x in
     TForall(x, infer_type_check_eff env body TEffPure)
+  | VCAbs(cs, body) ->
+    let cs = List.map (tr_constr env) cs in
+    let env = Env.add_constrs env cs in
+    TGuard(cs, infer_type_check_eff env body TEffPure)
   | VCtor(proof, n, tps, args) ->
     infer_ctor_type env proof n tps args (check_vtype env)
   | VExtern(_, tp) -> tr_type env tp
@@ -480,7 +530,7 @@ and infer_ctor_type env proof n tps args check_arg =
 (** Infer type of the expression, but check its effect *)
 and infer_type_check_eff env e eff =
   let (tp, eff') = infer_type_eff env e in
-  if Type.subeffect eff' eff then
+  if Type.subeffect (Env.constr_set env) eff' eff then
     tp
   else failwith "Internal effect error"
 
@@ -489,14 +539,14 @@ and infer_type_check_eff env e eff =
   *)
 and check_type_eff env e tp eff =
   let (tp', eff') = infer_type_eff env e in
-  if not (Type.subtype tp' tp) then
+  if not (Type.subtype (Env.constr_set env) tp' tp) then
     InterpLib.InternalError.report
       ~reason:"type mismatch"
       ~sloc:(SExprPrinter.tr_expr e)
       ~requested:(SExprPrinter.tr_type tp)
       ~provided:(SExprPrinter.tr_type tp')
       ();
-  if not (Type.subeffect eff' eff) then
+  if not (Type.subeffect (Env.constr_set env) eff' eff) then
     InterpLib.InternalError.report
       ~reason:"effect mismatch"
       ~sloc:(SExprPrinter.tr_expr e)
@@ -508,7 +558,7 @@ and check_type_eff env e tp eff =
 (** Check type of given value *)
 and check_vtype env v tp =
   let tp' = infer_vtype env v in
-  if Type.subtype tp' tp then
+  if Type.subtype (Env.constr_set env) tp' tp then
     ()
   else InterpLib.InternalError.report
     ~reason:"type mismatch"
@@ -521,84 +571,27 @@ and check_vtype env v tp =
   mutually recursive type definitions: in the first phase, the environment is
   extended, and in the second phase, bodies of the definitions are checked. *)
 and check_rec_defs env rds =
-  let rec_vars = List.map (fun (x, _, _) -> x) rds in
-  let (env, rds) = List.fold_left_map prepare_rec_def env rds in
-  List.iter (check_rec_def env rec_vars) rds;
+  let ((rec_env, env), rds) =
+    List.fold_left_map prepare_rec_def (env, env) rds in
+  List.iter (check_rec_def rec_env) rds;
   env
 
-(** The first phase of checking recursive definition. It returns the extended
-  environment, and untouched body of the definition together with the
-  refreshed type. Note that actual variable is forgotten, because the
-  environment is extended, so the variable is no longer needed. *)
-and prepare_rec_def env (x, tp, body) =
+(** The first phase of checking recursive definition. It returns two extended
+  environments (one for recursive definitions, and one for the body of
+  let-rec), and untouched body of the definition together with the refreshed
+  type. Note that actual variable is forgotten, because the environment is
+  extended, so the variable is no longer needed. *)
+and prepare_rec_def (rec_env, env) (x, tp, body) =
   let tp = tr_type env tp in
+  let rec_env = Env.add_rec_var rec_env x tp in
   let env = Env.add_var env x tp in
-  (env, (body, tp))
+  ((rec_env, env), (body, tp))
 
 (** Check if given body of recursive definition has expected type. The
-  function checks productiveness of the definition, so the list of variables
-  defined in the current recursive block should be provided. *)
-and check_rec_def env rec_vars (body, tp) =
-  check_vtype_productive env rec_vars body tp
-
-(** Check both type and productiveness of given value. Value is considered
-  productive if all non-trivial subexpressions are guarded by
-  lambda-abstraction with [NTerm] effect. The expression is considered
-  non-trivial if it is not a value or is a variable defined in current block
-  of recursive definitions. The [rec_vars] parameter should be a list of
-  such a variables. Only productive values can be used in recursive
-  definitions. *)
-and check_vtype_productive env rec_vars v tp =
-  match v with
-  | VNum _ | VNum64 _ | VStr _ | VExtern _ ->
-    check_vtype env v tp
-  | VVar x when not (List.exists (Var.equal x) rec_vars) ->
-    check_vtype env v tp
-
-  | VFn(x, xtp, body) ->
-    begin match body, tp with
-    | _, TArrow(_, _, eff) when Type.subeffect Effect.nterm eff ->
-      check_vtype env v tp
-    | EValue body, TArrow(tp1, tp2, _) ->
-      let xtp = tr_type env xtp in
-      if not (Type.subtype tp1 xtp) then
-        failwith "Internal type error";
-      let env = Env.add_var env x xtp in
-      let rec_vars = List.filter (Fun.negate (Var.equal x)) rec_vars in
-      check_vtype_productive env rec_vars body tp2
-    | _, TArrow _ ->
-      InterpLib.InternalError.report
-        ~reason:"non-productive recursive definition"
-        ()
-    | _ ->
-      failwith "Internal type error"
-    end
-
-  | VTFun(x, EValue body) ->
-    let (env, x) = Env.add_tvar env x in
-    begin match tp with
-    | TForall(y, tp) ->
-      begin match Kind.equal (TVar.kind x) (TVar.kind y) with
-      | Equal ->
-        let tp = Type.subst_type y (TVar x) tp in
-        check_vtype_productive env rec_vars body tp
-      | NotEqual ->
-        failwith "Internal kind error"
-      end
-    | _ -> failwith "Internal type error"
-    end
-
-  | VCtor(proof, n, tps, args) ->
-    let tp' = infer_ctor_type env proof n tps args
-      (check_vtype_productive env rec_vars) in
-    if Type.subtype tp' tp then
-      ()
-    else failwith "Internal type error"
-
-  | VVar _ | VTFun _ ->
-    InterpLib.InternalError.report
-      ~reason:"non-productive recursive definition"
-      ()
+  function is called on environment extended with [Env.add_rec_var] function,
+  so it also checks if the body is productive. *)
+and check_rec_def env (body, tp) =
+  check_type_eff env body tp TEffPure
 
 (** Check if given program is well-typed *)
 let check_program p =

--- a/src/Lang/Untyped.ml
+++ b/src/Lang/Untyped.ml
@@ -15,7 +15,7 @@ type expr =
   | ELet of var * expr * expr
     (** Let-expression *)
 
-  | ELetRec of (var * value) list * expr
+  | ELetRec of (var * expr) list * expr
     (** Mutually recursive let-definitions *)
 
   | EApp of value * value

--- a/src/TypeErase.ml
+++ b/src/TypeErase.ml
@@ -2,7 +2,7 @@
  * See LICENSE for details.
  *)
 
-(** Type erasure. *)
+(** Type erasure for Core programs *)
 
 module S = Lang.Core
 module T = Lang.Untyped
@@ -16,19 +16,20 @@ let tr_data_def (dd : S.data_def) e =
 (** Translate expression *)
 let rec tr_expr (e : S.expr) =
   match e with
-  | EValue v        -> tr_value v
+  | EValue v -> tr_value v
   | ELet(x, e1, e2) | ELetPure(x, e1, e2) ->
     T.ELet(x, tr_expr e1, tr_expr e2)
   | ELetIrr(_, _, e) -> tr_expr e
   | ELetRec(rds, e) ->
     T.ELetRec(
-      List.map (fun (x, _, v) -> (x, tr_productive_value v)) rds,
+      List.map (fun (x, _, e) -> (x, tr_expr e)) rds,
       tr_expr e)
+  | ERecCtx e -> tr_expr e
   | EApp(v1, v2) ->
     tr_value_v v1 (fun v1 ->
     tr_value_v v2 (fun v2 ->
     T.EApp(v1, v2)))
-  | ETApp(v, _) -> tr_value v
+  | ETApp(v, _) | ECApp v -> tr_value v
   | EData(dds, e) -> List.fold_right tr_data_def dds (tr_expr e)
   | EMatch(_, v, cls, _, _) ->
     tr_value_v v (fun v ->
@@ -50,20 +51,25 @@ and tr_value (v : S.value) =
   match v with
   | VNum _ | VNum64 _ | VStr _ | VVar _ | VFn _ | VCtor _ | VExtern _ ->
     tr_value_v v (fun v -> T.EValue v)
-  | VTFun(_, body) ->
+  | VTFun(_, body) | VCAbs(_, body) ->
     tr_expr body
 
 (** Translate value as a value, and pass it to given meta-continuation *)
 and tr_value_v (v : S.value) cont =
   match v with
-  | VNum _ | VNum64 _ | VStr _ | VVar _ | VFn _ | VExtern _ ->
-    cont (tr_productive_value v)
-  | VTFun(_, body) ->
+  | VNum n   -> cont (T.VNum n)
+  | VNum64 n -> cont (T.VNum64 n)
+  | VStr s   -> cont (T.VStr s)
+  | VVar x   -> cont (T.VVar x)
+  | VFn(x, _, body) -> cont (T.VFn(x, tr_expr body))
+  | VTFun(_, EValue v) | VCAbs(_, EValue v) -> tr_value_v v cont
+  | VTFun(_, body) | VCAbs(_, body) ->
     let x = Var.fresh () in
     T.ELet(x, tr_expr body, cont (T.VVar x))
   | VCtor(_, n, _, args) ->
     tr_value_vs args (fun args ->
     cont (T.VCtor(n, args)))
+  | VExtern(name, _) -> cont (T.VExtern name)
 
 (** Translate list of values and pass the result (list of values) to given
   meta-continuation *)
@@ -74,21 +80,6 @@ and tr_value_vs vs cont =
     tr_value_v  v  (fun v ->
     tr_value_vs vs (fun vs ->
     cont (v :: vs)))
-
-(** Translate a value as a value. The value should be productive *)
-and tr_productive_value (v : S.value) =
-  match v with
-  | VNum n -> T.VNum n
-  | VNum64 n -> T.VNum64 n
-  | VStr s -> T.VStr s
-  | VVar x -> T.VVar x
-  | VFn(x, _, body) -> T.VFn(x, tr_expr body)
-  | VTFun(_, EValue v) -> tr_productive_value v
-  | VTFun(_, _) ->
-    failwith "Internal-error: non-productive recursive value"
-  | VCtor(prf, n, tps, vs) ->
-    T.VCtor(n, List.map tr_productive_value vs)
-  | VExtern(name, _) -> T.VExtern name
 
 (** Translate a clause of pattern-matching *)
 and tr_clause (cl : S.match_clause) =


### PR DESCRIPTION
- Added effect constraints in Core.
- Modified definition of subeffecting in Core in a way that takes into account effect constraints.
- Modified the notion of productivity in recursive definitions: mutually recursive definitions are pure expressions (not necessarily values) that may refer to themself only under (but not necessarily directly) a new `ERecCtx` construct. This new construct is always impure.
- Modified Eval and Untyped, to allow recursive definitions to be any expression (but they must be productive, and use their continuation in a linear way).