### PR TITLE
ConE intermediate language and simple incremental SAT-solver

### DIFF
--- a/src/IncrSAT/Formula.ml
+++ b/src/IncrSAT/Formula.ml
@@ -1,0 +1,204 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Positive formulas *)
+
+(** Conjunctions of variables *)
+module Conj = PropVar.Set
+
+(** Sets of conjunctions. Formulae are in DNF. *)
+module ConjSet = Set.Make(Conj)
+
+type t = ConjSet.t BRef.t
+
+let top_data = ConjSet.singleton PropVar.Set.empty
+
+let top = BRef.create top_data
+
+let bot = BRef.create ConjSet.empty
+
+let var x = BRef.create (ConjSet.singleton (PropVar.Set.singleton x))
+
+let fresh_var () = var (PropVar.fresh ())
+
+(* ========================================================================= *)
+
+let simplify_conj conj =
+  let rec loop acc xs =
+    match xs with
+    | [] -> Some acc
+    | x :: xs ->
+      begin match PropVar.value x with
+      | True     -> loop acc xs
+      | False    -> None
+      | SameAs x -> loop (PropVar.Set.add x acc) xs
+      end
+  in
+  loop PropVar.Set.empty (PropVar.Set.elements conj)
+
+let fast_simplify data =
+  let rec loop acc conjs =
+    match conjs with
+    | [] -> acc
+    | conj :: conjs ->
+      begin match simplify_conj conj with
+      | None      -> loop acc conjs
+      | Some conj -> loop (ConjSet.add conj acc) conjs
+      end
+  in
+  loop ConjSet.empty (ConjSet.elements data)
+
+let subsumed conj data =
+  ConjSet.mem conj data ||
+  ConjSet.exists (Fun.flip PropVar.Set.subset conj) data
+
+let full_simplify data =
+  let rec loop acc conjs =
+    match conjs with
+    | [] -> acc
+    | conj :: conjs ->
+      begin match simplify_conj conj with
+      | None      -> loop acc conjs
+      | Some conj ->
+        if subsumed conj acc then loop acc conjs
+        else
+          let acc =
+            ConjSet.filter
+              (fun conj' -> not (PropVar.Set.subset conj conj'))
+              acc
+          in
+          loop (ConjSet.add conj acc) conjs
+      end
+  in
+  loop ConjSet.empty (ConjSet.elements data)
+
+(* ========================================================================= *)
+
+type bool3 = True | Unknown | False
+
+let value f =
+  let data = fast_simplify (BRef.get f) in
+  if ConjSet.mem PropVar.Set.empty data then begin
+    BRef.set f top_data;
+    True
+  end else begin
+    BRef.set f data;
+    if ConjSet.is_empty data then False
+    else Unknown
+  end
+
+let is_true f =
+  match value f with
+  | True -> true
+  | _    -> false
+
+let is_false f =
+  match value f with
+  | False -> true
+  | _     -> false
+
+let implies f1 f2 =
+  let data1 = fast_simplify (BRef.get f1) in
+  let data2 = full_simplify (BRef.get f2) in
+  BRef.set f1 data1;
+  BRef.set f2 data2;
+  ConjSet.for_all (fun conj -> subsumed conj data2) data1
+
+let conj f1 f2 =
+  match value f1 with
+  | True  -> f2
+  | False -> bot
+  | Unknown ->
+    begin match value f2 with
+    | True    -> f1
+    | False   -> bot
+    | Unknown ->
+      let f1 = BRef.get f1 in
+      let f2 = BRef.get f2 in
+      BRef.create
+        (ConjSet.fold
+          (fun c1 ->
+            ConjSet.fold
+              (fun c2 -> ConjSet.add (PropVar.Set.union c1 c2))
+              f2)
+          f1
+          ConjSet.empty)
+    end
+
+let disj f1 f2 =
+  match value f1 with
+  | True  -> top
+  | False -> f2
+  | Unknown ->
+    begin match value f2 with
+    | True    -> top
+    | False   -> f1
+    | Unknown -> BRef.create (ConjSet.union (BRef.get f1) (BRef.get f2))
+    end
+
+(* ========================================================================= *)
+
+let fix_conj conj =
+  match simplify_conj conj with
+  | None -> false
+  | Some conj ->
+    begin match PropVar.Set.choose_opt conj with
+    | None -> true
+    | Some x ->
+      PropVar.set_bool x false;
+      false
+    end
+
+let fix_conjs conjs =
+  ConjSet.exists fix_conj conjs
+
+let fix f =
+  fix_conjs (full_simplify (BRef.get f))
+
+(* ========================================================================= *)
+
+let imp_var_to_cnf f x =
+  let data = full_simplify (BRef.get f) in
+  BRef.set f data;
+  List.map
+    (fun conj ->
+      (x, true) :: List.map (fun y -> (y, false)) (PropVar.Set.elements conj))
+    (ConjSet.elements data)
+
+let var_imp_to_cnf x f =
+  let data = full_simplify (BRef.get f) in
+  BRef.set f data;
+  let var_cls =
+    List.map
+      (fun conj ->
+        let y   = PropVar.fresh () in
+        let cls =
+          List.map (fun z -> [(y, false); (z, true)])
+            (PropVar.Set.elements conj) in
+        (y, cls))
+      (ConjSet.elements data)
+  in
+  ((x, false) :: List.map (fun (y, _) -> (y, true)) var_cls) ::
+    List.concat_map snd var_cls
+
+let imp_to_cnf f1 f2 =
+  let x0 = PropVar.fresh () in
+  imp_var_to_cnf f1 x0 @
+  var_imp_to_cnf x0 f2
+
+(* ========================================================================= *)
+
+let conj_to_sexpr conj =
+  match PropVar.Set.elements conj with
+  | []  -> SExpr.Sym "true"
+  | [x] -> SExpr.List [Sym "var"; PropVar.to_sexpr x]
+  | xs  -> SExpr.List (Sym "and" :: List.map PropVar.to_sexpr xs)
+
+let to_sexpr f =
+  let data = full_simplify (BRef.get f) in
+  BRef.set f data;
+  match ConjSet.elements data with
+  | []     -> SExpr.Sym "false"
+  | [conj] -> conj_to_sexpr conj
+  | conjs  -> SExpr.List (Sym "or" :: List.map conj_to_sexpr conjs)

--- a/src/IncrSAT/Formula.mli
+++ b/src/IncrSAT/Formula.mli
@@ -1,0 +1,46 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Positive formulas *)
+
+type t
+
+(** Always true formula *)
+val top : t
+
+(* Always false formula *)
+val bot : t
+
+(** Propositional variable as a formula *)
+val var : PropVar.t -> t
+
+(** Formula build from a single fresh propositional variable *)
+val fresh_var : unit -> t
+
+(** Conjunction of two formuals *)
+val conj : t -> t -> t
+
+(** Disjunction of two formulas *)
+val disj : t -> t -> t
+
+(** Check if formula is trivially true *)
+val is_true : t -> bool
+
+(** Check if formula is trivially false *)
+val is_false : t -> bool
+
+(** Check if one formula trivially implies the other *)
+val implies : t -> t -> bool
+
+(** Set some propositional variables in order to fix its value. Return the
+  value of the formula *)
+val fix : t -> bool
+
+(** Convert implication to CNF, i.e, conjunction of disjunctions of litarals.
+  The boolean flag at each literal describes polarity: [false] means that
+  variable is negated. *)
+val imp_to_cnf : t -> t -> (PropVar.t * bool) list list
+
+(** Pretty-print formula as S-expression *)
+val to_sexpr : t -> SExpr.t

--- a/src/IncrSAT/PropVar.ml
+++ b/src/IncrSAT/PropVar.ml
@@ -1,0 +1,46 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Propositional variables *)
+
+type t =
+  { uid   : UID.t;
+    value : value option BRef.t
+  }
+
+and value =
+  | True
+  | False
+  | SameAs of t
+
+let fresh () =
+  { uid   = UID.fresh ();
+    value = BRef.create None
+  }
+
+let rec value x =
+  match BRef.get x.value with
+  | None -> SameAs x
+  | Some ((True | False) as v) -> v
+  | Some (SameAs y) ->
+    let v = value y in
+    BRef.set x.value (Some v);
+    v
+
+let set_bool x b =
+  match BRef.get x.value with
+  | None ->
+    BRef.set x.value (Some (if b then True else False))
+  | Some _ ->
+    assert false
+
+let to_sexpr x = SExpr.Sym (UID.to_string x.uid)
+
+module Ordered = struct
+  type nonrec t = t
+  let compare x y = UID.compare x.uid y.uid
+end
+
+module Set = Set.Make(Ordered)
+module Map = Map.Make(Ordered)

--- a/src/IncrSAT/PropVar.mli
+++ b/src/IncrSAT/PropVar.mli
@@ -1,0 +1,31 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Propositional variables *)
+
+type t
+
+(** Value of a variable *)
+type value =
+  | True
+  | False
+  | SameAs of t
+
+(** Create a fresh variable *)
+val fresh : unit -> t
+
+(** Get the value of the variable. *)
+val value : t -> value
+
+(** Set the value of the variable to some boolean value. *)
+val set_bool : t -> bool -> unit
+
+(** Pretty-print variable as S-expression *)
+val to_sexpr : t -> SExpr.t
+
+(** Finite sets of propositional variables *)
+module Set : Set.S with type elt = t
+
+(** Finite maps from propositional variables *)
+module Map : Map.S with type key = t

--- a/src/IncrSAT/Solver.ml
+++ b/src/IncrSAT/Solver.ml
@@ -1,0 +1,219 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Simple incremental SAT-solver *)
+
+type lit = PropVar.t * bool
+
+type 'a clause =
+  { lits   : lit list;
+    origin : 'a
+  }
+
+type 'a solve_result =
+  | Ok
+  | Error of 'a
+
+type 'a t =
+  { clauses : 'a clause list BRef.t;
+    status  : 'a solve_result BRef.t;
+  }
+
+let create () =
+  { clauses = BRef.create [];
+    status  = BRef.create Ok
+  }
+
+(* ========================================================================= *)
+
+let view_lits lits =
+  let rec loop acc lits =
+    match lits with
+    | [] -> Some (PropVar.Map.bindings acc)
+    | (x, pol) :: lits ->
+      begin match PropVar.value x with
+      | True ->
+        if pol then None
+        else loop acc lits
+      | False ->
+        if pol then loop acc lits
+        else None
+      | SameAs x ->
+        begin match PropVar.Map.find_opt x acc with
+        | None      -> loop (PropVar.Map.add x pol acc) lits
+        | Some pol' ->
+          if pol = pol' then loop acc lits
+          else None
+        end
+      end
+  in
+  loop PropVar.Map.empty lits
+
+(* ========================================================================= *)
+
+exception Solver_error
+
+let rec simplify_clauses status cls =
+  let dirty = ref false in
+  let simplify_clause cl =
+    match view_lits cl.lits with
+    | None -> None
+    | Some [] ->
+      BRef.set status (Error cl.origin);
+      raise Solver_error
+    | Some [(x, pol)] ->
+      dirty := true;
+      PropVar.set_bool x pol;
+      None
+    | Some lits -> Some { cl with lits = lits }
+  in
+  let cls = List.filter_map simplify_clause cls in
+  if !dirty then simplify_clauses status cls
+  else cls
+
+let add_imply solver origin p1 p2 =
+  let cls =
+    List.map (fun lits -> { origin; lits }) (Formula.imp_to_cnf p1 p2) in
+  match simplify_clauses solver.status cls with
+  | cls ->
+    BRef.set solver.clauses (cls @ BRef.get solver.clauses)
+  | exception Solver_error ->
+    ()
+
+(* ========================================================================= *)
+
+let solve_partial solver =
+  (* TODO: do something. *)
+  match BRef.get solver.status with
+  | Ok  -> Ok
+  | err -> err
+
+(* ========================================================================= *)
+
+let collect_lit_vars (pos_vars, neg_vars) (x, pol) =
+  if pol then
+    (PropVar.Set.add x pos_vars, neg_vars)
+  else
+    (pos_vars, PropVar.Set.add x neg_vars)
+
+let collect_clause_vars vars cl =
+  List.fold_left collect_lit_vars vars cl.lits
+
+let collect_vars cls =
+  List.fold_left collect_clause_vars (PropVar.Set.empty, PropVar.Set.empty)
+    cls
+
+(* ========================================================================= *)
+
+type dom = { mutable dom_state : dom_state }
+and dom_state =
+  | Root of UID.t
+  | Node of dom
+
+let rec find_root dom =
+  match dom.dom_state with
+  | Root _ -> dom
+  | Node dom' ->
+    let root = find_root dom' in
+    dom.dom_state <- Node root;
+    root
+
+let split_to_domains cls =
+  let dom_data = Hashtbl.create 32 in
+  let dom_map  = ref PropVar.Map.empty in
+  let new_dom () =
+    let uid = UID.fresh () in
+    Hashtbl.add dom_data uid [];
+    { dom_state = Root uid }
+  in
+  let var_dom x =
+    match PropVar.Map.find_opt x !dom_map with
+    | Some dom -> dom
+    | None ->
+      let dom = new_dom () in
+      dom_map := PropVar.Map.add x dom !dom_map;
+      dom
+  in
+  let add_clause dom cl =
+    match (find_root dom).dom_state with
+    | Root uid ->
+      Hashtbl.replace dom_data uid (cl :: Hashtbl.find dom_data uid)
+    | Node _ -> assert false
+  in
+  let union_dom dom1 dom2 =
+    let dom1 = find_root dom1 in
+    let dom2 = find_root dom2 in
+    match dom1.dom_state, dom2.dom_state with
+    | Root uid1, Root uid2 when uid1 = uid2 -> ()
+    | Root uid1, Root uid2 ->
+      let cls1 = Hashtbl.find dom_data uid1 in
+      let cls2 = Hashtbl.find dom_data uid2 in
+      Hashtbl.replace dom_data uid1 (cls2 @ cls1);
+      Hashtbl.remove dom_data uid2;
+      dom2.dom_state <- Node dom1
+    | _ -> assert false
+  in
+  let proc_clause cl =
+    match cl.lits with
+    | [] -> assert false
+    | (x, _) :: lits ->
+      let dom = var_dom x in
+      add_clause dom cl;
+      List.iter (fun (y, _) -> union_dom dom (var_dom y)) lits
+  in
+  List.iter proc_clause cls;
+  Hashtbl.to_seq_values dom_data
+
+(* ========================================================================= *)
+
+let rec solve_clauses status cls =
+  let cls = simplify_clauses status cls in
+  let (pos_vars, neg_vars) = collect_vars cls in
+  let only_neg = PropVar.Set.diff neg_vars pos_vars in
+  match PropVar.Set.is_empty only_neg with
+  | false ->
+    PropVar.Set.iter (Fun.flip PropVar.set_bool false) only_neg;
+    solve_clauses status cls
+  | true ->
+    let only_pos = PropVar.Set.diff pos_vars neg_vars in
+    begin match PropVar.Set.is_empty only_pos with
+    | false ->
+      PropVar.Set.iter (Fun.flip PropVar.set_bool true) only_pos;
+      solve_clauses status cls
+    | true ->
+      Seq.iter (solve_domain status) (split_to_domains cls)
+    end
+
+and solve_domain status cls =
+  match cls with
+  | [] -> ()
+  | { lits = []; origin } :: _ ->
+    BRef.set status (Error origin);
+    raise Solver_error
+  | { lits = ((x, pol) :: _); _ } :: _ ->
+    begin try
+      BRef.bracket (fun () ->
+        PropVar.set_bool x pol;
+        solve_clauses status cls)
+    with
+    | Solver_error ->
+      PropVar.set_bool x (not pol);
+      solve_clauses status cls
+    end
+
+let solve_all solver =
+  match BRef.get solver.status with
+  | Ok ->
+    begin try
+      let cls = simplify_clauses solver.status (BRef.get solver.clauses) in
+      Seq.iter (solve_clauses solver.status) (split_to_domains cls);
+      Ok
+    with
+    | Solver_error ->
+      begin match BRef.get solver.status with
+      | Ok  -> assert false
+      | err -> err
+      end
+    end
+  | err -> err

--- a/src/IncrSAT/Solver.mli
+++ b/src/IncrSAT/Solver.mli
@@ -1,0 +1,25 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Simple incremental SAT-solver *)
+
+type 'a t
+
+(** Create a new solver *)
+val create : unit -> 'a t
+
+(** Add formula implication with attached value. *)
+val add_imply : 'a t -> 'a -> Formula.t -> Formula.t -> unit
+
+(** Result of a solver *)
+type 'a solve_result =
+  | Ok
+  | Error of 'a
+
+(** Partially solve collected clauses, trying to quickly fail if the clause
+  set is not satisfiable *)
+val solve_partial : 'a t -> 'a solve_result
+
+(** Solve all the collected clauses *)
+val solve_all : 'a t -> 'a solve_result

--- a/src/IncrSAT/dune
+++ b/src/IncrSAT/dune
@@ -1,0 +1,3 @@
+(library
+  (name incrSAT)
+  (libraries utils))

--- a/src/Lang/ConE.ml
+++ b/src/Lang/ConE.ml
@@ -1,0 +1,52 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** The ConE (constraints on effects) language: the result of the
+  effect-inference phase. *)
+
+include ConEPriv.TypeBase
+include ConEPriv.Syntax
+
+type formula = IncrSAT.Formula.t
+
+type subst = ConEPriv.Subst.t
+
+module TVar    = ConEPriv.TVar
+module GVar    = ConEPriv.Effct.GVar
+
+module Effct = struct
+  include ConEPriv.Effct
+  let subst = ConEPriv.Subst.in_effect
+end
+
+module CEffect = ConEPriv.CEffect
+
+module Type = struct
+  include ConEPriv.TypeBase
+  let collect_gvars = ConEPriv.Type.collect_gvars
+  let subst = ConEPriv.Subst.in_type
+  let to_sexpr = ConEPriv.SExprPrinter.tr_type
+end
+
+module Scheme = struct
+  let is_monomorphic = ConEPriv.Type.is_monomorphic
+  let of_type = ConEPriv.Type.scheme_of_type
+  let to_type = ConEPriv.Type.scheme_to_type
+  let collect_gvars = ConEPriv.Type.collect_scheme_gvars
+  let collect_gvars_p = ConEPriv.Type.collect_scheme_gvars_p
+  let subst = ConEPriv.Subst.in_scheme
+  let to_sexpr = ConEPriv.SExprPrinter.tr_scheme
+end
+
+module CtorDecl = ConEPriv.CtorDecl
+
+module Constr = struct
+  let to_sexpr = ConEPriv.SExprPrinter.tr_constr
+end
+
+module Subst = ConEPriv.Subst
+
+module BuiltinType = UnifCommon.BuiltinType
+
+let to_sexpr = ConEPriv.SExprPrinter.tr_program

--- a/src/Lang/ConE.mli
+++ b/src/Lang/ConE.mli
@@ -393,7 +393,8 @@ module Type : sig
 
     | THandler of (** Handler type *)
       { tvar    : tvar;
-          (** Type variable that represents the handled effect. *)
+          (** Type variable that represents the handled effect. It's bound in
+            [cap_tp], [in_tp] and [in_eff]. *)
 
         cap_tp  : typ;
           (** Capability type. *)
@@ -534,7 +535,7 @@ module BuiltinType : sig
   (** Int type *)
   val tv_int : tvar
 
-  (** Int type *)
+  (** Int64 type *)
   val tv_int64 : tvar
 
   (** String type *)

--- a/src/Lang/ConE.mli
+++ b/src/Lang/ConE.mli
@@ -260,6 +260,9 @@ module TVar : sig
   (** Check if type variable belongs to the given scope. *)
   val in_scope : tvar -> Scope.t -> bool
 
+  (** Get the unique identifier for pretty-printing *)
+  val pp_uid : tvar -> PPTree.uid
+
   (** Finite sets of type variables *)
   module Set : Set.S with type elt = tvar
 

--- a/src/Lang/ConE.mli
+++ b/src/Lang/ConE.mli
@@ -1,0 +1,559 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** The ConE (constraints on effects) language: the result of the
+  effect-inference phase. *)
+
+(** Formulas used for effect guards *)
+type formula = IncrSAT.Formula.t
+
+(** Kinds (shared with Unif) *)
+type kind = UnifCommon.Kind.t
+
+(** Name of type variable *)
+type tname = UnifCommon.Names.tname
+
+(** Name of named parameter *)
+type name = UnifCommon.Names.name
+
+(** Type variables *)
+type tvar
+
+(** Named type variable *)
+type named_tvar = tname * tvar
+
+(** Generalizable effect variable *)
+type gvar
+
+(** Composable effects *)
+type effct
+
+(** Computation effect of an expression. Purity implies termination. *)
+type ceffect =
+  | Pure
+  | Impure of effct
+
+(** Abstract type that represents a type. Use [Type.view] to access the
+  top-most constructor. *)
+type typ
+
+(** Polymorphic type scheme *)
+type scheme =
+  { sch_targs : named_tvar list;
+    (** Universally quantified type variables *)
+
+    sch_named : named_scheme list;
+    (** Schemes of named parameters *)
+
+    sch_body  : typ
+    (** Scheme body *)
+  }
+
+(** Named type scheme *)
+and named_scheme = name * scheme
+
+(** Declaration of ADT constructor *)
+type ctor_decl =
+  { ctor_name        : string;
+      (** Name of the constructor *)
+
+    ctor_targs       : named_tvar list;
+      (** Existential type variables of the constructor *)
+
+    ctor_named       : named_scheme list;
+      (** Named parameters of the constructor *)
+
+    ctor_arg_schemes : scheme list
+      (** Type schemes of the regular parameters *)
+  }
+
+(** Subeffecting constraint, stating that the first effect is a subeffect
+  of the second. *)
+type constr = effct * effct
+
+(** Substitutions of types for type variables *)
+type subst
+
+(* ========================================================================= *)
+
+(** Variable *)
+type var = Var.t
+
+(** Data-like definition (ADT or label) *)
+type data_def =
+  | DD_Data of (** Algebraic datatype *)
+    { tvar  : tvar;
+        (** Type variable that represents the ADT *)
+
+      proof : var;
+        (** An irrelevant variable that stores the proof that this ADT has
+          the following constructors *)
+
+      args  : named_tvar list;
+        (** List of type parameters of the ADT *)
+
+      ctors : ctor_decl list;
+        (** List of constructors of the ADT *)
+
+      positive : bool
+        (** A flag indicating if the type is positively recursive (in
+          particular, not recursive at all) and therefore can be deconstructed
+          without performing NTerm effect. *)
+    }
+
+  | DD_Label of (** First-class label *)
+    { tvar      : tvar;
+        (** Type variable that represents effect of this label *)
+
+      var       : var;
+        (** Regular variable that would store the label *)
+
+      delim_tp  : typ;
+        (** Type of the delimiter *)
+
+      delim_eff : effct
+        (** Effect of the delimiter *)
+    }
+
+(** Expressions *)
+type expr =
+  | EUnitPrf
+    (** ADT-shape proof for unit type *)
+
+  | EOptionPrf
+    (** ADT-shape proof for option type *)
+
+  | ENum of int
+    (** Integer literal *)
+
+  | ENum64 of int64
+    (** 64 bit integer literal *)
+
+  | EStr of string
+    (** String literal *)
+
+  | EChr of char
+    (** Character literal *)
+
+  | EVar of var
+    (** Variable *)
+
+  | EFn of var * scheme * expr
+    (** Lambda abstraction *)
+
+  | ETFun of tvar * expr
+    (** Type abstraction *)
+
+  | ECAbs of constr list * expr
+    (** Constraint abstraction *)
+
+  | EApp of expr * expr
+    (** Function application *)
+
+  | ETApp of expr * typ
+    (** Type application *)
+
+  | ECApp of expr
+    (** Instantiation of constraint abstraction *)
+
+  | ELet of var * expr * expr
+    (** Let-binding *)
+
+  | ELetPure of var * expr * expr
+    (** Let-binding of a pure expression *)
+
+  | ELetRec of rec_def list * expr
+    (** Recursive let-binding *)
+
+  | ERecCtx of expr
+    (** Context for mutually recursive definitions. It is always impure, and
+      from that point recursive definitions become visible. It is also used
+      to mark the place where less polymorphic variables should be let-bound
+      during the translation from Unif. *)
+
+  | EData of data_def list * expr
+    (** Mutually recursive datatype definitions *)
+
+  | ECtor of expr * int * typ list * expr list
+    (** Fully applied ADT constructor. The first argument is the ADt shape
+      proof, and the second argument is the index of the constructor. The
+      remaining arguments are the constructor arguments. *)
+
+  | EMatch of expr * expr * match_clause list * typ * ceffect
+    (** Pattern matching. The first parameter is the proof that the type of
+      the matched value is an ADT *)
+
+  | EShift of expr * var * expr * typ
+    (** Shift-0 operator parametrized by runtime tag, binder for continuation
+      variable, body, and the type of the whole expression. *)
+
+  | EReset of expr * expr * var * expr
+    (** Reset-0 operator parametrized by runtime tag, body, and the return
+      clause *)
+
+  | EExtern of string * typ
+    (** Externally defined value *)
+
+  | ERepl of (unit -> expr) * typ * ceffect
+    (** REPL. It is a function that prompts user for another input. It returns
+      an expression to evaluate, usually containing another REPL expression.
+      *)
+
+  | EReplExpr of expr * string * expr
+    (** Print type (second parameter), evaluate and print the first expression,
+      then continue to the second expression. *)
+
+(** Recursive definition *)
+and rec_def =
+  { rd_var    : var;
+      (** Variable that stores recursive value. *)
+
+    rd_body   : expr;
+      (** Body of the recursive definition. It should already abstract
+        [rd_evars] and [rd_constr]. *)
+
+    rd_evars  : tvar list;
+      (** Effect variables abstracted in the recursive value. *)
+
+    rd_constr : constr list;
+      (** Constraints on effect variables *)
+
+    rd_scheme : scheme
+      (** Scheme of the body. *)
+  }
+
+(** Pattern-matching clause *)
+and match_clause =
+  { cl_tvars : tvar list;
+    (** Type variables introduced by the clause *)
+
+    cl_vars  : var list;
+    (** Variables introduced by the clause *)
+
+    cl_body  : expr
+    (** Body of the clause *)
+  }
+
+(** Programs *)
+type program = expr
+
+(* ========================================================================= *)
+(** Operations on type variables *)
+module TVar : sig
+  (** Kind of a type variable *)
+  val kind : tvar -> kind
+
+  (** Create fresh type variable of the effect kind. *)
+  val fresh_eff : scope:Scope.t -> tvar
+
+  (** Fresh type variable, that uses metadata (ppuid, kind) from the given
+    Unif type variable *)
+  val clone_unif : scope:Scope.t -> UnifCommon.TVar.t -> tvar
+
+  (** Fresh type variable that uses metadata from the given type variable *)
+  val clone : scope:Scope.t -> tvar -> tvar
+
+  (** Check equality of type variables *)
+  val equal : tvar -> tvar -> bool
+
+  (** Check if type variable belongs to the given scope. *)
+  val in_scope : tvar -> Scope.t -> bool
+
+  (** Finite sets of type variables *)
+  module Set : Set.S with type elt = tvar
+
+  (** Finite map from type variables *)
+  module Map : Map.S with type key = tvar
+
+  (** Pretty-print type variable as S-expression *)
+  val to_sexpr : tvar -> SExpr.t
+end
+
+(* ========================================================================= *)
+(** Operations on generalizable variables *)
+module GVar : sig
+  (** Get the scope of a generalizable variable *)
+  val scope : gvar -> Scope.t
+
+  (** Check if generalizable variable belongs to the given scope. *)
+  val in_scope : gvar -> Scope.t -> bool
+
+  (** Update a scope of generalizable variable. The new scope should be
+    an ancestor of the current one. Additionally, the list [tvars] of "bound"
+    variables might be passed (all of them must have effect kind). The
+    generalizable variable is substituted with effect [Y,X1?p1, ..., Xn?pn]
+    where [Y] is a fresh generalizable variable at the new scope, [X1...Xn]
+    are those "bound" variables that are in the current scope of a
+    generalizable variable. Each of them appears conditionally as described
+    by formulas [p1,...,pn], that are pairwise distinct fresh propositional
+    variables. Function returns [Y] variable, which might be the same as
+    the current one, when there are no bound variables to add. *)
+  val update_scope : scope:Scope.t -> tvars:tvar list -> gvar -> gvar
+
+  (** Globally substitute an effect for a given generalizable variable.
+    The effect should belongs to the scope of the variable. This operation
+    can be done only once for each generalizable variable. *)
+  val set : gvar -> effct -> unit
+
+  (** Promote to regular type variable. *)
+  val fix : gvar -> tvar
+
+  (** Pretty-print the generalizable variable as S-expression. *)
+  val to_sexpr : gvar -> SExpr.t
+
+  (** Finite sets of generalizable variables *)
+  module Set : Set.S with type elt = gvar
+
+  (** Finite maps from generalizable variables *)
+  module Map : Map.S with type key = gvar
+end
+
+(* ========================================================================= *)
+(** Operations on effects *)
+module Effct : sig
+  (** Pure effect. It still allows non-termination. *)
+  val pure : effct
+
+  (** Effect that contains a single effect variable. *)
+  val var : tvar -> effct
+
+  (** Effect that contains a single generalizable variable *)
+  val gvar : gvar -> effct
+
+  (** Join of two effects *)
+  val join : effct -> effct -> effct
+
+  (** Create effect that is equal to the given effect, when the formula is
+    satisfied, and equal to the pure effect when the formula is not satisfied.
+    *)
+  val guard : effct -> formula -> effct
+
+  (** Remove all components of the effect that do not belong to the given
+    scope. *)
+  val filter_to_scope : scope:Scope.t -> effct -> effct
+
+  (** Generate a fresh generalizable variable and convert it into an effect. *)
+  val fresh_gvar : scope:Scope.t -> effct
+
+  (** Reveal the representation of the effect: two list of atomic effects
+    with predicates that states if the atomic effect belongs to the effect. *)
+  val view : effct -> (tvar * formula) list * (gvar * formula) list
+
+  (** Lookup a type variable in the effect. Returns formula that indicates if
+    a type variable is included in the effect. *)
+  val lookup_tvar : effct -> tvar -> formula
+
+  (** Lookup a generalizable variable in the effect. Returns formula that
+    indicates if a generalizable variable is included in the effect. *)
+  val lookup_gvar : effct -> gvar -> formula
+
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add them to the given set. *)
+  val collect_gvars : scope:Scope.t -> effct -> GVar.Set.t -> GVar.Set.t
+
+  (** Apply the substitution to the effect. *)
+  val subst : subst -> effct -> effct
+
+  (** Pretty-print the effect as S-expression. *)
+  val to_sexpr : effct -> SExpr.t
+end
+
+(* ========================================================================= *)
+(** Operations on computation effects *)
+module CEffect : sig
+  (** Expected effect of the whole program *)
+  val prog_effect : ceffect
+
+  (** Join two computation effects. *)
+  val join : ceffect -> ceffect -> ceffect
+
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add them to the given set. *)
+  val collect_gvars : scope:Scope.t -> ceffect -> GVar.Set.t -> GVar.Set.t
+end
+
+(* ========================================================================= *)
+(** Operations on types *)
+module Type : sig
+  (** View of the type. *)
+  type type_view =
+    | TVar     of tvar
+      (** Regular type variable *)
+
+    | TArrow   of scheme * typ * ceffect
+      (** Arrow type *)
+
+    | TLabel   of effct * typ * effct
+      (** Label type with the delimited effect, and the type type and effect
+        of the delimiter. *)
+
+    | THandler of (** Handler type *)
+      { tvar    : tvar;
+          (** Type variable that represents the handled effect. *)
+
+        cap_tp  : typ;
+          (** Capability type. *)
+
+        in_tp   : typ;
+          (** Type of the inner computation. *)
+
+        in_eff  : effct;
+          (** Effect of the inner computation. Usually it contains [tvar]. *)
+
+        out_tp  : typ;
+          (** Type of the result. *)
+
+        out_eff : effct
+          (** Effect of the result. *)
+      }
+
+    | TEffect  of effct
+      (** Effect *)
+
+    | TApp     of typ * typ
+      (** Type application *)
+
+  (** Regular type variable *)
+  val t_var : tvar -> typ
+
+  (** Arrow type *)
+  val t_arrow : scheme -> typ -> ceffect -> typ
+
+  (** Pure arrow *)
+  val t_pure_arrow : scheme -> typ -> typ
+
+  (** Sequence of pure arrows *)
+  val t_pure_arrows : scheme list -> typ -> typ
+
+  (** Handler type *)
+  val t_handler : tvar -> typ -> typ -> effct -> typ -> effct -> typ
+
+  (** Label type *)
+  val t_label : effct -> typ -> effct -> typ
+
+  (** Type application *)
+  val t_app : typ -> typ -> typ
+
+  (** Sequence of type applications *)
+  val t_apps : typ -> typ list -> typ
+
+  (** Effect *)
+  val t_effect : effct -> typ
+
+  (** Reveal the top-most constructor of the type. *)
+  val view : typ -> type_view
+
+  (** Convert the type (of the effect kind) to an effect. *)
+  val to_effect : typ -> effct
+
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add them to the given set. *)
+  val collect_gvars : scope:Scope.t -> typ -> GVar.Set.t -> GVar.Set.t
+
+  (** Apply the substitution to the type. *)
+  val subst : subst -> typ -> typ
+
+  (** Pretty-print type as S-expression *)
+  val to_sexpr : typ -> SExpr.t
+end
+
+(* ========================================================================= *)
+(** Operations on type schemes *)
+module Scheme : sig
+  (** Check if the scheme is monomorphic. *)
+  val is_monomorphic : scheme -> bool
+
+  (** Convert a type to a monomorphic scheme *)
+  val of_type : typ -> scheme
+
+  (** Convert scheme to monomorphic type. Returns [None], when the scheme is
+    polymorphic. *)
+  val to_type : scheme -> typ option
+
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add them to the given set. *)
+  val collect_gvars : scope:Scope.t -> scheme -> GVar.Set.t -> GVar.Set.t
+
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add the to the given sets, depending on their polarity. The
+    former set stores non-negative variables, while the latter stores
+    non-positive variables. Invariant variables are added to both sets. *)
+  val collect_gvars_p : scope:Scope.t -> scheme ->
+    GVar.Set.t * GVar.Set.t -> GVar.Set.t * GVar.Set.t
+
+  (** Apply the substitution to the scheme. *)
+  val subst : subst -> scheme -> scheme
+
+  (** Pretty-print type scheme as S-expression *)
+  val to_sexpr : scheme -> SExpr.t
+end
+
+(* ========================================================================= *)
+(** Operations on constructor declarations *)
+module CtorDecl : sig
+  (** Collect all generalizable variables that do not belong to the given
+    scope and add them to the given set. *)
+  val collect_gvars : scope:Scope.t -> ctor_decl -> GVar.Set.t -> GVar.Set.t
+
+  (** Apply the substitution to the constructor declaration. *)
+  val subst : subst -> ctor_decl -> ctor_decl
+end
+
+(* ========================================================================= *)
+(** Operations on constraints *)
+module Constr : sig
+  (** Pretty-print constraint as S-expression *)
+  val to_sexpr : constr -> SExpr.t
+end
+
+(* ========================================================================= *)
+(** Operations on substitutions *)
+module Subst : sig
+  (** Empty substitution *)
+  val empty : subst
+
+  (** Add a renaming to the substitution. [rename sub x y] is equivalent to
+    [add sub x (Type.t_var y)]. *)
+  val rename : subst -> tvar -> tvar -> subst
+
+  (** Add a type to the substitution. *)
+  val add : subst -> tvar -> typ -> subst
+
+  (** Create a new substitution that maps given type variables to the
+    corresponding types. Both list must have equal lengths. *)
+  val for_named_tvars : named_tvar list -> typ list -> subst
+end
+
+(* ========================================================================= *)
+(** Built-in types *)
+module BuiltinType : sig
+  (** Int type *)
+  val tv_int : tvar
+
+  (** Int type *)
+  val tv_int64 : tvar
+
+  (** String type *)
+  val tv_string : tvar
+
+  (** Char type *)
+  val tv_char : tvar
+
+  (** Unit type *)
+  val tv_unit : tvar
+
+  (** Option type *)
+  val tv_option : tvar
+
+  (** IO effect *)
+  val tv_io : tvar
+
+  (** List of all built-in types with their names *)
+  val all : (string * tvar) list
+end
+
+(* ========================================================================= *)
+
+(** Produce S-expression representation of the program *)
+val to_sexpr : program -> SExpr.t

--- a/src/Lang/ConEPriv/CEffect.ml
+++ b/src/Lang/ConEPriv/CEffect.ml
@@ -1,0 +1,27 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Computation effects with distinguished purity *)
+
+type t =
+  | Pure
+  | Impure of Effct.t
+
+let prog_effect = Impure (Effct.var UnifCommon.BuiltinType.tv_io)
+
+let join eff1 eff2 =
+  match eff1, eff2 with
+  | Pure, _ -> eff2
+  | _, Pure -> eff1
+  | Impure eff1, Impure eff2 -> Impure (Effct.join eff1 eff2)
+
+let collect_gvars ~scope eff gvs =
+  match eff with
+  | Pure       -> gvs
+  | Impure eff -> Effct.collect_gvars ~scope eff gvs
+
+let to_sexpr eff =
+  match eff with
+  | Pure       -> SExpr.Sym "pure"
+  | Impure eff -> Effct.to_sexpr eff

--- a/src/Lang/ConEPriv/CEffect.mli
+++ b/src/Lang/ConEPriv/CEffect.mli
@@ -1,0 +1,22 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Computation effects with distinguished purity *)
+
+type t =
+  | Pure
+  | Impure of Effct.t
+
+(** Expected effect of the whole program *)
+val prog_effect : t
+
+(** Join two computation effects. *)
+val join : t -> t -> t
+
+(** Collect all generalizable variables that do not belong to the given
+  scope and add them to the given set. *)
+val collect_gvars : scope:Scope.t -> t -> Effct.GVar.Set.t -> Effct.GVar.Set.t
+
+(** Pretty-print effect as S-expression *)
+val to_sexpr : t -> SExpr.t

--- a/src/Lang/ConEPriv/CtorDecl.ml
+++ b/src/Lang/ConEPriv/CtorDecl.ml
@@ -1,0 +1,23 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Operations on constructor declarations *)
+
+open TypeBase
+
+let collect_gvars ~scope ctor gvs =
+  let { ctor_name = _; ctor_targs = _; ctor_named; ctor_arg_schemes } = ctor
+  in
+  let gvs =
+    List.fold_left
+      (fun gvs (_, sch) -> Type.collect_scheme_gvars ~scope sch gvs)
+      gvs
+      ctor_named
+  in
+  List.fold_left
+    (fun gvs sch -> Type.collect_scheme_gvars ~scope sch gvs)
+    gvs
+    ctor_arg_schemes
+
+let subst = Subst.in_ctor_decl

--- a/src/Lang/ConEPriv/Effct.ml
+++ b/src/Lang/ConEPriv/Effct.ml
@@ -1,0 +1,298 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Internal representation of effects in the ConE language. *)
+
+(* The effect is represented as a pair of maps: one from regular effect
+  variables, and one from generalizable variables. Both maps assigns formula
+  to a variable, indicating if the variable is present in the effect. The
+  second map is represented as a map from UIDs, because of the circular
+  dependencies between types. *)
+
+type formula = IncrSAT.Formula.t
+
+type t =
+  { tvars : formula TVar.Map.t BRef.t;
+    gvars : gvar_map BRef.t
+  }
+
+and gvar_map = (gvar * formula) UID.Map.t
+
+and gvar =
+  { uid   : UID.t;
+    state : gvar_state BRef.t
+  }
+
+and gvar_state =
+  | GVar   of Scope.t
+    (** Proper generalizable variable that belongs to the given scope. *)
+
+  | Effect of t
+    (** The generalizable variable was globally replaced with given effect. *)
+
+(* ========================================================================= *)
+module TVarMap : sig
+  type t = formula TVar.Map.t
+
+  val empty     : t
+  val singleton : TVar.t -> formula -> t
+  val filter    : (TVar.t -> formula -> bool) -> t -> t
+  val add       : TVar.t -> formula -> t -> t
+  val union     : t -> t -> t
+  val guard     : t -> formula -> t
+  val lookup    : t -> TVar.t -> formula
+  val to_list   : t -> (TVar.t * formula) list
+end = struct
+  type t = formula TVar.Map.t
+
+  let empty = TVar.Map.empty
+  let singleton = TVar.Map.singleton
+  let filter = TVar.Map.filter
+
+  let add x p m =
+    match TVar.Map.find_opt x m with
+    | None    -> TVar.Map.add x p m
+    | Some p2 -> TVar.Map.add x (IncrSAT.Formula.disj p p2) m
+
+  let union =
+    TVar.Map.union (fun _ p1 p2 -> Some (IncrSAT.Formula.disj p1 p2))
+
+  let guard m p =
+    if IncrSAT.Formula.is_true p then m
+    else TVar.Map.map (IncrSAT.Formula.conj p) m
+
+  let lookup m x =
+    match TVar.Map.find_opt x m with
+    | None   -> IncrSAT.Formula.bot
+    | Some p -> p
+
+  let to_list = TVar.Map.bindings
+end
+
+(* ========================================================================= *)
+module GVarMap : sig
+  type t = gvar_map
+
+  val empty     : t
+  val singleton : gvar -> formula -> t
+  val filter    : (gvar -> formula -> bool) -> t -> t
+  val add       : gvar -> formula -> t -> t
+  val fold      : (gvar -> formula -> 'a -> 'a) -> t -> 'a -> 'a
+  val union     : t -> t -> t
+  val guard     : t -> formula -> t
+  val lookup    : t -> gvar -> formula
+  val to_list   : t -> (gvar * formula) list
+end = struct
+  type t = gvar_map
+
+  let empty = UID.Map.empty
+  let singleton gv p = UID.Map.singleton gv.uid (gv, p)
+  let filter f m = UID.Map.filter (fun _ (gv, p) -> f gv p) m
+
+  let add gv p m =
+    match UID.Map.find_opt gv.uid m with
+    | None         -> UID.Map.add gv.uid (gv, p) m
+    | Some (_, p2) -> UID.Map.add gv.uid (gv, IncrSAT.Formula.disj p p2) m
+
+  let fold f m a = UID.Map.fold (fun _ (gv, p) -> f gv p) m a
+
+  let union =
+    UID.Map.union
+      (fun _ (u1, p1) (u2, p2) ->
+        assert (u1.uid = u2.uid);
+        Some (u1, IncrSAT.Formula.disj p1 p2))
+
+  let guard m p =
+    if IncrSAT.Formula.is_true p then m
+    else UID.Map.map (fun (gv, p1) -> (gv, IncrSAT.Formula.conj p1 p)) m
+
+  let lookup m gv =
+    match UID.Map.find_opt gv.uid m with
+    | None       -> IncrSAT.Formula.bot
+    | Some(_, p) -> p
+
+  let to_list m = UID.Map.bindings m |> List.map snd
+end
+
+(* ========================================================================= *)
+
+let pure =
+  { tvars = BRef.create TVarMap.empty;
+    gvars = BRef.create GVarMap.empty
+  }
+
+let var x =
+  { tvars = BRef.create (TVarMap.singleton x IncrSAT.Formula.top);
+    gvars = BRef.create GVarMap.empty
+  }
+
+let gvar gv =
+  { tvars = BRef.create TVarMap.empty;
+    gvars = BRef.create (GVarMap.singleton gv IncrSAT.Formula.top)
+  }
+
+let cons x p eff =
+  { tvars = BRef.create (TVarMap.add x p (BRef.get eff.tvars));
+    gvars = BRef.create (BRef.get eff.gvars)
+  }
+
+let join eff1 eff2 =
+  { tvars =
+      BRef.create (TVarMap.union (BRef.get eff1.tvars) (BRef.get eff2.tvars));
+    gvars =
+      BRef.create (GVarMap.union (BRef.get eff1.gvars) (BRef.get eff2.gvars))
+  }
+
+let guard eff p =
+  if IncrSAT.Formula.is_true p then eff
+  else
+    { tvars = BRef.create (TVarMap.guard (BRef.get eff.tvars) p);
+      gvars = BRef.create (GVarMap.guard (BRef.get eff.gvars) p)
+    }
+
+let fresh_gvar ~scope =
+  gvar { uid = UID.fresh (); state = BRef.create (GVar scope) }
+
+(* ========================================================================= *)
+
+module GVar = struct
+  module Ordered = struct
+    type t = gvar
+    let compare gv1 gv2 = UID.compare gv1.uid gv2.uid
+  end
+
+  let scope gv =
+    match BRef.get gv.state with
+    | GVar scope -> scope
+    | Effect _ -> assert false
+
+  let get_scope = scope
+
+  let in_scope gv scope =
+    Scope.mem (get_scope gv) scope
+
+  let update_scope ~scope ~tvars gv =
+    let tvars = List.filter (Fun.flip TVar.in_scope (get_scope gv)) tvars in
+    match tvars, BRef.get gv.state with
+    | [], GVar old_scope ->
+      assert (Scope.subset scope old_scope);
+      BRef.set gv.state (GVar scope);
+      gv
+
+    | _, GVar old_scope ->
+      let new_gv =
+        { uid   = UID.fresh ();
+          state = BRef.create (GVar scope)
+        } in
+      let tm =
+        List.fold_left
+          (fun tm x -> TVarMap.add x (IncrSAT.Formula.fresh_var ()) tm)
+          TVarMap.empty
+          tvars in
+      let eff =
+        { tvars = BRef.create tm;
+          gvars = BRef.create (GVarMap.singleton new_gv IncrSAT.Formula.top)
+        } in
+      BRef.set gv.state (Effect eff);
+      new_gv
+
+    | _, Effect _ -> assert false
+
+  let set gv eff =
+    match BRef.get gv.state with
+    | GVar   _ -> BRef.set gv.state (Effect eff)
+    | Effect _ -> assert false
+
+  let fix gv =
+    let x = TVar.fresh_eff ~scope:(scope gv) in
+    set gv (var x);
+    x
+
+  module Set = Set.Make(Ordered)
+  module Map = Map.Make(Ordered)
+
+  let to_sexpr gv =
+    match BRef.get gv.state with
+    | GVar scope ->
+      SExpr.List [ Sym ("?" ^ UID.to_string gv.uid); Scope.to_sexpr scope ]
+    | Effect _ -> SExpr.Sym ("effect")
+end
+
+(* ========================================================================= *)
+
+let rec view_map eff =
+  let tm =
+    BRef.get eff.tvars
+    |> TVarMap.filter (fun _ p -> not (IncrSAT.Formula.is_false p)) in
+  let (tm, gm) =
+    GVarMap.fold view_add_gvar (BRef.get eff.gvars) (tm, GVarMap.empty) in
+  BRef.set eff.tvars tm;
+  BRef.set eff.gvars gm;
+  (tm, gm)
+
+and view_add_gvar gv p (tm, gm) =
+  if IncrSAT.Formula.is_false p then (tm, gm)
+  else
+    match BRef.get gv.state with
+    | GVar _     -> (tm, GVarMap.add gv p gm)
+    | Effect eff ->
+      let (tm2, gm2) = view_map eff in
+      let tm = TVarMap.union tm (TVarMap.guard tm2 p) in
+      let gm = GVarMap.union gm (GVarMap.guard gm2 p) in
+      (tm, gm)
+
+let view eff =
+  let (tm, gm) = view_map eff in
+  (TVarMap.to_list tm, GVarMap.to_list gm)
+
+let take_tvars eff =
+  let (tm, gm) = view_map eff in
+  let eff =
+    { tvars = BRef.create TVarMap.empty;
+      gvars = BRef.create gm
+    } in
+  (TVarMap.to_list tm, eff)
+
+let lookup_tvar eff x =
+  let (tm, _) = view_map eff in
+  TVarMap.lookup tm x
+
+let lookup_gvar eff gv =
+  let (_, gm) = view_map eff in
+  GVarMap.lookup gm gv
+
+(* ========================================================================= *)
+
+let filter_to_scope ~scope eff =
+  let (tm, gm) = view_map eff in
+  { tvars =
+      TVarMap.filter (fun x  _ -> TVar.in_scope x  scope) tm
+      |> BRef.create;
+    gvars =
+      GVarMap.filter (fun gv _ -> GVar.in_scope gv scope) gm
+      |> BRef.create
+  }
+
+(* ========================================================================= *)
+
+let collect_gvars ~scope eff gvs =
+  let (_, gm) = view_map eff in
+  GVarMap.fold
+    (fun gv _ gvs ->
+      if GVar.in_scope gv scope then gvs
+      else GVar.Set.add gv gvs)
+    gm
+    gvs
+
+(* ========================================================================= *)
+
+let guarded_to_sexpr to_sexpr (x, p) =
+  if IncrSAT.Formula.is_true p then to_sexpr x
+  else SExpr.List [ to_sexpr x; Sym "?"; IncrSAT.Formula.to_sexpr p ]
+
+let to_sexpr eff =
+  let (tvs, gvs) = view eff in
+  SExpr.List
+    (List.map (guarded_to_sexpr TVar.to_sexpr) tvs @
+     List.map (guarded_to_sexpr GVar.to_sexpr) gvs)

--- a/src/Lang/ConEPriv/Effct.mli
+++ b/src/Lang/ConEPriv/Effct.mli
@@ -1,0 +1,94 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Internal representation of effects in the ConE language. *)
+
+(** Formulas used for effect guards. *)
+type formula = IncrSAT.Formula.t
+
+(** Generalizable variable *)
+type gvar
+
+type t
+
+(** Operations on generalizable variables *)
+module GVar : sig
+  (** Get the scope of a generalizable variable *)
+  val scope : gvar -> Scope.t
+
+  (** Check if generalizable variable belongs to the given scope. *)
+  val in_scope : gvar -> Scope.t -> bool
+
+  (** Update the scope of generalizable variable. See [Lang.ConE] for details.
+    *)
+  val update_scope : scope:Scope.t -> tvars:TVar.t list -> gvar -> gvar
+
+  (** Globally substitute an effect for a given generalizable variable.
+    The effect should belongs to the scope of the variable. This operation
+    can be done only once for each generalizable variable. *)
+  val set : gvar -> t -> unit
+
+  (** Promote to regular type variable. *)
+  val fix : gvar -> TVar.t
+
+  (** Pretty-print the generalizable variable as S-expression. *)
+  val to_sexpr : gvar -> SExpr.t
+
+  (** Finite sets of generalizable variables *)
+  module Set : Set.S with type elt = gvar
+
+  (** Finite maps from generalizable variables *)
+  module Map : Map.S with type key = gvar
+end
+
+(** Pure effect. It still allows non-termination. *)
+val pure : t
+
+(** Effect that contains a single effect variable. *)
+val var : TVar.t -> t
+
+(** Effect that contains a single generalizable variable *)
+val gvar : gvar -> t
+
+(** Extend the effect with a type variable *)
+val cons : TVar.t -> formula -> t -> t
+
+(** Join of two effects *)
+val join : t -> t -> t
+
+(** Create effect that is equal to the given effect, when the formula is
+  satisfied, and equal to the pure effect when the formula is not satisfied.
+  *)
+val guard : t -> formula -> t
+
+(** Remove all components of the effect that do not belong to the given
+  scope. *)
+val filter_to_scope : scope:Scope.t -> t -> t
+
+(** Generate a fresh generalizable variable and convert it into an effect. *)
+val fresh_gvar : scope:Scope.t -> t
+
+(** Reveal the representation of the effect: two list of atomic effects
+  with predicates that states if the atomic effect belongs to the effect. *)
+val view : t -> (TVar.t * formula) list * (gvar * formula) list
+
+(** Split the effect into a list of type variables (together with the
+  predicates), and the remaining effect built only from generalizable
+  variables. *)
+val take_tvars : t -> (TVar.t * formula) list * t
+
+(** Lookup a type variable in the effect. Returns formula that indicates if
+  a type variable is included in the effect. *)
+val lookup_tvar : t -> TVar.t -> formula
+
+(** Lookup a generalizable variable in the effect. Returns formula that
+  indicates if a generalizable variable is included in the effect. *)
+val lookup_gvar : t -> gvar -> formula
+
+(** Collect all generalizable variables that do not belong to the given
+  scope and add them to the given set. *)
+val collect_gvars : scope:Scope.t -> t -> GVar.Set.t -> GVar.Set.t
+
+(** Pretty-print the effect as S-expression. *)
+val to_sexpr : t -> SExpr.t

--- a/src/Lang/ConEPriv/SExprPrinter.ml
+++ b/src/Lang/ConEPriv/SExprPrinter.ml
@@ -1,0 +1,204 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Translating ConE to S-expressions *)
+
+open SExpr
+open TypeBase
+open Syntax
+
+let tr_kind = UnifCommon.Kind.to_sexpr
+
+let tr_tvar = TVar.to_sexpr
+
+let tr_tvar_binder x =
+  List [ tr_tvar x; tr_kind (UnifCommon.TVar.kind x) ]
+
+let tr_named_tvar_binder (_, x) =
+  tr_tvar_binder x
+
+let rec tr_type tp =
+  match view tp with
+  | TVar x -> tr_tvar x
+  | TArrow _ -> List (tr_arrow tp)
+  | TLabel(eff, delim_tp, delim_eff) ->
+    List [Sym "label";
+      Effct.to_sexpr eff;
+      tr_type delim_tp;
+      Effct.to_sexpr delim_eff]
+  | THandler h ->
+    List [Sym "handler";
+      tr_tvar h.tvar;
+      tr_type h.cap_tp;
+      tr_type h.in_tp;
+      Effct.to_sexpr h.in_eff;
+      tr_type h.out_tp;
+      Effct.to_sexpr h.out_eff]
+  | TEffect eff ->
+    List [Sym "effect"; Effct.to_sexpr eff]
+  | TApp _ -> tr_type_app tp []
+
+and tr_arrow tp =
+  match view tp with
+  | TArrow(sch, tp2, Pure) -> tr_scheme sch :: tr_arrow tp2
+  | TArrow(sch, tp2, eff) ->
+    [ tr_scheme sch; Sym "->"; tr_type tp2; CEffect.to_sexpr eff]
+  | _ -> [ Sym "->"; tr_type tp ]
+
+and tr_type_app tp args =
+  match view tp with
+  | TApp(tp1, tp2) -> tr_type_app tp1 (tr_type tp2 :: args)
+
+  | TVar _ | TArrow _ | TLabel _ | THandler _ | TEffect _ ->
+    List (Sym "app" :: tr_type tp :: args)
+
+and tr_scheme sch =
+  List [
+    Sym "forall";
+    List (List.map tr_named_tvar_binder sch.sch_targs);
+    List (List.map tr_named_scheme sch.sch_named);
+    tr_type sch.sch_body ]
+
+and tr_named_scheme (_, sch) =
+  tr_scheme sch
+
+let tr_constr (eff1, eff2) =
+  List [ Effct.to_sexpr eff1; Sym "<:"; Effct.to_sexpr eff2 ]
+
+(* ========================================================================= *)
+
+let tr_var x = Sym (Var.unique_name x)
+
+let tr_ctor_decl (ctor : ctor_decl) =
+  List (
+    Sym ctor.ctor_name ::
+    List (List.map tr_named_tvar_binder ctor.ctor_targs) ::
+    List (List.map tr_named_scheme ctor.ctor_named) ::
+    List.map tr_scheme ctor.ctor_arg_schemes)
+
+let tr_data_def (dd : data_def) =
+  match dd with
+  | DD_Data adt ->
+    List (
+      (if adt.positive then Sym "positive-data" else Sym "data") ::
+      tr_tvar adt.tvar ::
+      tr_var  adt.proof ::
+      List (List.map tr_named_tvar_binder adt.args) ::
+      List.map tr_ctor_decl adt.ctors)
+
+  | DD_Label lbl ->
+    List [
+      Sym "label";
+      tr_tvar lbl.tvar;
+      tr_var lbl.var;
+      tr_type lbl.delim_tp;
+      Effct.to_sexpr lbl.delim_eff
+    ]
+
+(* ========================================================================= *)
+
+let rec tr_expr (e : expr) =
+  match e with
+  | EUnitPrf   -> Sym "unit-prf"
+  | EOptionPrf -> Sym "option-prf"
+  | ENum n     -> Sym (string_of_int n)
+  | ENum64 n   -> Sym (Int64.to_string n ^ "L")
+  | EStr s     -> Sym (Printf.sprintf "\"%s\"" (String.escaped s))
+  | EChr c     -> Sym (Printf.sprintf "\'%s\'" (Char.escaped c))
+  | EVar x     -> tr_var x
+  | EFn _      -> List (Sym "fn" :: tr_fn e)
+  | ETFun _    -> List (Sym "tfun" :: tr_tfun e)
+  | ECAbs(cs, e) ->
+    List [ Sym "cabs"; List (List.map tr_constr cs); tr_expr e ]
+  | EApp _ | ETApp _ | ECApp _ -> tr_app e []
+  | ELet _ | ELetPure _ | ELetRec _ | ERecCtx _ | EData _ | EReset _ ->
+    List (Sym "defs" :: tr_defs e)
+  | ECtor(prf, idx, tps, es) ->
+    List (
+      Sym "ctor" ::
+      Sym (string_of_int idx) ::
+      List (List.map tr_type tps) ::
+      List.map tr_expr es)
+  | EMatch(proof, e, cls, tp, eff) ->
+    List [ Sym "match"; tr_expr proof; tr_expr e;
+      List (Sym "clauses" :: List.map tr_clause cls);
+      tr_type tp; CEffect.to_sexpr eff ]
+  | EShift(lbl, k, body, tp) ->
+    List
+      [ Sym "shift";
+        tr_expr lbl;
+        tr_var k;
+        tr_type tp;
+        tr_expr body ]
+  | EExtern(name, tp) ->
+    List [ Sym "extern"; Sym name; tr_type tp ]
+  | ERepl(_, tp, eff) ->
+    List [ Sym "repl"; tr_type tp; CEffect.to_sexpr eff ]
+  | EReplExpr(e1, tp, e2) ->
+    List [ Sym "repl-expr"; tr_expr e1; Sym ("{" ^ tp ^ "}"); tr_expr e2 ]
+
+and tr_fn e =
+  match e with
+  | EFn(x, sch, e) ->
+    List [ tr_var x; tr_scheme sch ] :: tr_fn e
+  | _ -> [ tr_expr e ]
+
+and tr_tfun e =
+  match e with
+  | ETFun(x, e) -> tr_tvar_binder x :: tr_tfun e
+  | _ -> [ tr_expr e ]
+
+and tr_app e args =
+  match e with
+  | EApp(e1, e2) -> tr_app e1 (tr_expr e2 :: args)
+  | ETApp(e1, tp) -> tr_app e1 (List [ Sym "type"; tr_type tp ] :: args)
+  | ECApp e1 -> tr_app e1 (Sym "constr" :: args)
+  
+  | EUnitPrf | EOptionPrf | ENum _ | ENum64 _ | EStr _ | EChr _ | EVar _
+  | EFn _ | ETFun _ | ECAbs _ | ELet _ | ELetPure _ | ELetRec _ | ERecCtx _
+  | EData _ | ECtor _ | EMatch _ | EShift _ | EReset _ | EExtern _
+  | ERepl _ | EReplExpr _ ->
+    List (tr_expr e :: args)
+
+and tr_defs e =
+  match e with
+  | ELet(x, e1, e2) ->
+    List [ Sym "let"; tr_var x; tr_expr e1 ] :: tr_defs e2
+  | ELetPure(x, e1, e2) ->
+    List [ Sym "let-pure"; tr_var x; tr_expr e1 ] :: tr_defs e2
+  | ELetRec(rds, e2) ->
+    List (Sym "let-rec" :: List.map tr_rec_def rds) :: tr_defs e2
+  | ERecCtx e2 -> List [ Sym "rec-ctx" ] :: tr_defs e2
+  | EData(dds, e2) ->
+    List (Sym "data" :: List.map tr_data_def dds) :: tr_defs e2
+  | EReset(lbl, body, x, ret) ->
+    List
+      [ Sym "reset";
+        tr_expr lbl;
+        tr_var x; tr_expr ret
+      ] :: tr_defs body
+
+  | EUnitPrf | EOptionPrf | ENum _ | ENum64 _ | EStr _ | EChr _ | EVar _
+  | EFn _ | ETFun _ | ECAbs _ | EApp _ | ETApp _ | ECApp _ | ECtor _
+  | EMatch _ | EShift _ | EExtern _ | ERepl _ | EReplExpr _ ->
+    [ tr_expr e ]
+
+and tr_rec_def rd =
+  List [
+    tr_var rd.rd_var;
+    List (Sym "evars"   :: List.map tr_tvar rd.rd_evars);
+    List (Sym "constrs" :: List.map tr_constr rd.rd_constr);
+    tr_scheme rd.rd_scheme;
+    tr_expr   rd.rd_body
+  ]
+
+and tr_clause (c : Syntax.match_clause) =
+  List (
+    List (Sym "tvars" :: List.map tr_tvar_binder c.cl_tvars) ::
+    List (Sym "vars" :: List.map tr_var c.cl_vars) ::
+    tr_defs c.cl_body)
+
+(* ========================================================================= *)
+
+let tr_program = tr_expr

--- a/src/Lang/ConEPriv/SExprPrinter.mli
+++ b/src/Lang/ConEPriv/SExprPrinter.mli
@@ -1,0 +1,16 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Translating ConE to S-expressions *)
+
+open TypeBase
+open Syntax
+
+val tr_type : typ -> SExpr.t
+
+val tr_scheme : scheme -> SExpr.t
+
+val tr_constr : constr -> SExpr.t
+
+val tr_program : program -> SExpr.t

--- a/src/Lang/ConEPriv/Subst.ml
+++ b/src/Lang/ConEPriv/Subst.ml
@@ -1,0 +1,121 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Substitutions *)
+
+open TypeBase
+
+type t = typ TVar.Map.t
+
+let empty = TVar.Map.empty
+
+let is_empty sub = TVar.Map.is_empty sub
+
+let add sub x tp = TVar.Map.add x tp sub
+
+let rename sub x y = add sub x (t_var y)
+
+let for_named_tvars xs tps =
+  List.fold_left2 (fun sub (_, x) tp -> add sub x tp) empty xs tps
+
+(* ========================================================================= *)
+
+let open_tvar sub x =
+  let y = TVar.clone ~scope:Scope.any x in
+  (rename sub x y, y)
+
+let open_named_tvar sub (name, x) =
+  let (sub, x) = open_tvar sub x in
+  (sub, (name, x))
+
+let open_named_tvars sub xs =
+  List.fold_left_map open_named_tvar sub xs
+
+(* ========================================================================= *)
+
+let in_effect_rec sub eff =
+  let (tvs, eff) = Effct.take_tvars eff in
+  List.fold_left
+    (fun eff (x, p) ->
+      match TVar.Map.find_opt x sub with
+      | None    -> Effct.cons x p eff
+      | Some tp -> Effct.join eff (Effct.guard (to_effect tp) p))
+    eff tvs
+
+let in_ceffect_rec sub eff =
+  match eff with
+  | Pure       -> Pure
+  | Impure eff -> Impure (in_effect_rec sub eff)
+
+let rec in_type_rec sub tp =
+  match view tp with
+  | TVar x ->
+    begin match TVar.Map.find_opt x sub with
+    | None    -> tp
+    | Some tp -> tp
+    end
+
+  | TArrow(sch, tp, eff) ->
+    t_arrow
+      (in_scheme_rec sub sch)
+      (in_type_rec sub tp)
+      (in_ceffect_rec sub eff)
+
+  | TLabel(eff, delim_tp, delim_eff) ->
+    t_label
+      (in_effect_rec sub eff)
+      (in_type_rec   sub delim_tp)
+      (in_effect_rec sub delim_eff)
+
+  | THandler { tvar; cap_tp; in_tp; in_eff; out_tp; out_eff } ->
+    let (sub_in, tvar) = open_tvar sub tvar in
+    t_handler
+      tvar
+      (in_type_rec   sub_in cap_tp)
+      (in_type_rec   sub_in in_tp)
+      (in_effect_rec sub_in in_eff)
+      (in_type_rec   sub    out_tp)
+      (in_effect_rec sub    out_eff)
+
+  | TEffect eff ->
+    t_effect (in_effect_rec sub eff)
+
+  | TApp(tp1, tp2) ->
+    t_app (in_type_rec sub tp1) (in_type_rec sub tp2)
+
+and in_scheme_rec sub sch =
+  let (sub, targs) = open_named_tvars sub sch.sch_targs in
+  { sch_targs = targs;
+    sch_named = List.map (in_named_scheme_rec sub) sch.sch_named;
+    sch_body  = in_type_rec sub sch.sch_body
+  }
+
+and in_named_scheme_rec sub (name, sch) =
+  (name, in_scheme_rec sub sch)
+
+(* ========================================================================= *)
+
+let in_effect sub eff =
+  if is_empty sub then eff
+  else in_effect_rec sub eff
+
+let in_type sub tp =
+  if is_empty sub then tp
+  else in_type_rec sub tp
+
+let in_scheme sub sch =
+  if is_empty sub then sch
+  else in_scheme_rec sub sch
+
+(* ========================================================================= *)
+
+let in_ctor_decl sub ctor =
+  if is_empty sub then ctor
+  else
+    let (sub, targs) = open_named_tvars sub ctor.ctor_targs in
+    { ctor_name  = ctor.ctor_name;
+      ctor_targs = targs;
+      ctor_named = List.map (in_named_scheme_rec sub) ctor.ctor_named;
+      ctor_arg_schemes = List.map (in_scheme_rec sub) ctor.ctor_arg_schemes
+    }

--- a/src/Lang/ConEPriv/Subst.mli
+++ b/src/Lang/ConEPriv/Subst.mli
@@ -1,0 +1,34 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Substitutions *)
+
+open TypeBase
+
+type t
+
+(** Empty substitution *)
+val empty : t
+
+(** Add a renaming to the substitution. *)
+val rename : t -> tvar -> tvar -> t
+
+(** Add a type to the substitution. *)
+val add : t -> tvar -> typ -> t
+
+(** Create a new substitution that maps given type variables to the
+  corresponding types. Both list must have equal lengths. *)
+val for_named_tvars : named_tvar list -> typ list -> t
+
+(** Apply the substitution to an effect *)
+val in_effect : t -> effct -> effct
+
+(** Apply the substitution to a type *)
+val in_type : t -> typ -> typ
+
+(** Apply the substitution to a type scheme *)
+val in_scheme : t -> scheme -> scheme
+
+(** Apply the substitution to a constructor declaration *)
+val in_ctor_decl : t -> ctor_decl -> ctor_decl

--- a/src/Lang/ConEPriv/Syntax.ml
+++ b/src/Lang/ConEPriv/Syntax.ml
@@ -1,0 +1,67 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Syntax of the ConE language. *)
+
+open TypeBase
+
+type var = Var.t
+
+type data_def =
+  | DD_Data of
+    { tvar     : tvar;
+      proof    : var;
+      args     : named_tvar list;
+      ctors    : ctor_decl list;
+      positive : bool
+    }
+  | DD_Label of
+    { tvar      : tvar;
+      var       : var;
+      delim_tp  : typ;
+      delim_eff : effct
+    }
+
+type expr =
+  | EUnitPrf
+  | EOptionPrf
+  | ENum      of int
+  | ENum64    of int64
+  | EStr      of string
+  | EChr      of char
+  | EVar      of var
+  | EFn       of var * scheme * expr
+  | ETFun     of tvar * expr
+  | ECAbs     of constr list * expr
+  | EApp      of expr * expr
+  | ETApp     of expr * typ
+  | ECApp     of expr
+  | ELet      of var * expr * expr
+  | ELetPure  of var * expr * expr
+  | ELetRec   of rec_def list * expr
+  | ERecCtx   of expr
+  | EData     of data_def list * expr
+  | ECtor     of expr * int * typ list * expr list
+  | EMatch    of expr * expr * match_clause list * typ * ceffect
+  | EShift    of expr * var * expr * typ
+  | EReset    of expr * expr * var * expr
+  | EExtern   of string * typ
+  | ERepl     of (unit -> expr) * typ * ceffect
+  | EReplExpr of expr * string * expr
+
+and rec_def =
+  { rd_var    : var;
+    rd_body   : expr;
+    rd_evars  : tvar list;
+    rd_constr : constr list;
+    rd_scheme : scheme
+  }
+
+and match_clause =
+  { cl_tvars : tvar list;
+    cl_vars  : var list;
+    cl_body  : expr
+  }
+
+type program = expr

--- a/src/Lang/ConEPriv/TVar.ml
+++ b/src/Lang/ConEPriv/TVar.ml
@@ -1,0 +1,11 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Type variables *)
+
+include UnifCommon.TVar
+
+let fresh_eff ~scope = fresh ~scope UnifCommon.Kind.k_effect
+
+let clone_unif = clone

--- a/src/Lang/ConEPriv/TVar.mli
+++ b/src/Lang/ConEPriv/TVar.mli
@@ -1,0 +1,35 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Type variables *)
+
+type t = UnifCommon.TVar.t
+
+(** Kind of a type variable *)
+val kind : t -> UnifCommon.Kind.t
+
+(** Create fresh type variable of the effect kind. *)
+val fresh_eff : scope:Scope.t -> t
+
+(** Fresh type variable, that uses metadata (ppuid, kind) from the given
+  Unif type variable *)
+val clone_unif : scope:Scope.t -> UnifCommon.TVar.t -> t
+
+(** Fresh type variable that uses metadata from the given type variable *)
+val clone : scope:Scope.t -> t -> t
+
+(** Check equality of type variables *)
+val equal : t -> t -> bool
+
+(** Check if a type variable can be used in a given scope *)
+val in_scope : t -> Scope.t -> bool
+
+(** Finite sets of type variables *)
+module Set : Set.S with type elt = t
+
+(** Finite map from type variables *)
+module Map : Map.S with type key = t
+
+(** Pretty-print type variable as S-expression *)
+val to_sexpr : t -> SExpr.t

--- a/src/Lang/ConEPriv/TVar.mli
+++ b/src/Lang/ConEPriv/TVar.mli
@@ -25,6 +25,9 @@ val equal : t -> t -> bool
 (** Check if a type variable can be used in a given scope *)
 val in_scope : t -> Scope.t -> bool
 
+(** Get the unique identifier for pretty-printing *)
+val pp_uid : t -> PPTree.uid
+
 (** Finite sets of type variables *)
 module Set : Set.S with type elt = t
 

--- a/src/Lang/ConEPriv/Type.ml
+++ b/src/Lang/ConEPriv/Type.ml
@@ -1,0 +1,102 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Other operations on types and related constructs *)
+
+open TypeBase
+
+let rec collect_gvars ~scope tp gvs =
+  match view tp with
+  | TVar x -> gvs
+  | TArrow(sch, tp, eff) ->
+    collect_scheme_gvars ~scope sch gvs
+    |> collect_gvars ~scope tp
+    |> CEffect.collect_gvars ~scope eff
+  | TLabel(eff, delim_tp, delim_eff) ->
+    Effct.collect_gvars ~scope eff gvs
+    |> collect_gvars ~scope delim_tp
+    |> Effct.collect_gvars ~scope delim_eff
+  | THandler { tvar = _; cap_tp; in_tp; in_eff; out_tp; out_eff } ->
+    collect_gvars ~scope cap_tp gvs
+    |> collect_gvars ~scope in_tp
+    |> Effct.collect_gvars ~scope in_eff
+    |> collect_gvars ~scope out_tp
+    |> Effct.collect_gvars ~scope out_eff
+  | TEffect eff ->
+    Effct.collect_gvars ~scope eff gvs
+  | TApp(tp1, tp2) ->
+    collect_gvars ~scope tp1 gvs |> collect_gvars ~scope tp2
+
+and collect_scheme_gvars ~scope sch gvs =
+  List.fold_left
+    (fun gvs (_, sch) -> collect_scheme_gvars ~scope sch gvs)
+    gvs
+    sch.sch_named
+  |> collect_gvars ~scope sch.sch_body
+
+(* ========================================================================= *)
+
+let swap_pair (x, y) = (y, x)
+
+let collect_effect_gvars_p ~scope eff (pgvs, ngvs) =
+  (Effct.collect_gvars ~scope eff pgvs, ngvs)
+
+let collect_effect_gvars_n ~scope eff (pgvs, ngvs) =
+  (pgvs, Effct.collect_gvars ~scope eff ngvs)
+
+let collect_ceffect_gvars_p ~scope eff (pgvs, ngvs) =
+  (CEffect.collect_gvars ~scope eff pgvs, ngvs)
+
+let collect_gvars_i ~scope tp (pgvs, ngvs) =
+  let gvs = collect_gvars ~scope tp Effct.GVar.Set.empty in
+  (Effct.GVar.Set.union gvs pgvs, Effct.GVar.Set.union gvs ngvs)
+
+let rec collect_gvars_p ~scope tp gvsp =
+  match view tp with
+  | TVar x -> gvsp
+  | TArrow(sch, tp, eff) ->
+    collect_scheme_gvars_n ~scope sch gvsp
+    |> collect_gvars_p ~scope tp
+    |> collect_ceffect_gvars_p ~scope eff
+  | THandler { tvar = _; cap_tp; in_tp; in_eff; out_tp; out_eff } ->
+    collect_gvars_p ~scope cap_tp gvsp
+    |> collect_gvars_n ~scope in_tp
+    |> collect_effect_gvars_n ~scope in_eff
+    |> collect_gvars_p ~scope out_tp
+    |> collect_effect_gvars_p ~scope out_eff
+  | TLabel _ | TApp _ ->
+    collect_gvars_i ~scope tp gvsp
+  
+  | TEffect _ -> failwith "Internal kind error"
+
+and collect_gvars_n ~scope tp gvsp =
+  gvsp |> swap_pair |> collect_gvars_p ~scope tp |> swap_pair
+
+and collect_scheme_gvars_p ~scope sch gvsp =
+  List.fold_left
+    (fun gvsp (_, sch) -> collect_scheme_gvars_n ~scope sch gvsp)
+    gvsp
+    sch.sch_named
+  |> collect_gvars_p ~scope sch.sch_body
+
+and collect_scheme_gvars_n ~scope sch gvsp =
+  gvsp |> swap_pair |> collect_scheme_gvars_p ~scope sch |> swap_pair
+
+(* ========================================================================= *)
+
+let scheme_to_type sch =
+  match sch with
+  | { sch_targs = []; sch_named = []; sch_body = tp } -> Some tp
+  | _ -> None
+
+let is_monomorphic sch =
+  match scheme_to_type sch with
+  | Some _ -> true
+  | None -> false
+
+let scheme_of_type tp =
+  { sch_targs = [];
+    sch_named = [];
+    sch_body  = tp
+  }

--- a/src/Lang/ConEPriv/TypeBase.ml
+++ b/src/Lang/ConEPriv/TypeBase.ml
@@ -1,0 +1,85 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Internal representation of types in the ConE language. *)
+
+type kind  = UnifCommon.Kind.t
+type tname = UnifCommon.Names.tname
+type name  = UnifCommon.Names.name
+
+module TVar = UnifCommon.TVar
+type tvar       = TVar.t
+type named_tvar = tname * tvar
+
+type gvar  = Effct.gvar
+type effct = Effct.t
+
+type ceffect = CEffect.t =
+  | Pure
+  | Impure of effct
+
+type typ = type_view
+
+and scheme =
+  { sch_targs : named_tvar list;
+    sch_named : named_scheme list;
+    sch_body  : typ
+  }
+
+and named_scheme = name * scheme
+
+and type_view =
+  | TVar     of tvar
+  | TArrow   of scheme * typ * ceffect
+  | TLabel   of effct * typ * effct
+  | THandler of
+    { tvar    : tvar;
+      cap_tp  : typ;
+      in_tp   : typ;
+      in_eff  : effct;
+      out_tp  : typ;
+      out_eff : effct
+    }
+  | TEffect  of effct
+  | TApp     of typ * typ
+
+type ctor_decl =
+  { ctor_name        : string;
+    ctor_targs       : named_tvar list;
+    ctor_named       : named_scheme list;
+    ctor_arg_schemes : scheme list
+  }
+
+type constr = effct * effct
+
+let t_var x = TVar x
+
+let t_arrow sch tp eff = TArrow(sch, tp, eff)
+
+let t_pure_arrow sch tp = t_arrow sch tp Pure
+
+let t_pure_arrows schs tp =
+  List.fold_right t_pure_arrow schs tp
+
+let t_label eff delim_tp delim_eff = TLabel(eff, delim_tp, delim_eff)
+
+let t_handler tvar cap_tp in_tp in_eff out_tp out_eff =
+  THandler { tvar; cap_tp; in_tp; in_eff; out_tp; out_eff }
+
+let t_effect eff = TEffect eff
+
+let t_app tp1 tp2 = TApp (tp1, tp2)
+
+let t_apps tp tps = List.fold_left t_app tp tps
+
+let view tp = tp
+
+let to_effect tp =
+  match view tp with
+  | TVar    x   -> Effct.var x
+  | TEffect eff -> eff
+  | TArrow _ | TLabel _ | THandler _ ->
+    failwith "Internal kind error"
+  | TApp _ ->
+    failwith "Internal error: type application in effect"

--- a/src/Lang/ConEPriv/TypeBase.mli
+++ b/src/Lang/ConEPriv/TypeBase.mli
@@ -1,0 +1,67 @@
+(* This file is part of DBL, released under MIT license.
+ * See LICENSE for details.
+ *)
+
+(** Internal representation of types in the ConE language. *)
+
+type kind  = UnifCommon.Kind.t
+type tname = UnifCommon.Names.tname
+type name  = UnifCommon.Names.name
+
+type tvar       = TVar.t
+type named_tvar = tname * tvar
+
+type gvar  = Effct.gvar
+type effct = Effct.t
+
+type ceffect = CEffect.t =
+  | Pure
+  | Impure of effct
+
+type typ
+
+type scheme =
+  { sch_targs : named_tvar list;
+    sch_named : named_scheme list;
+    sch_body  : typ
+  }
+
+and named_scheme = name * scheme
+
+type type_view =
+  | TVar     of tvar
+  | TArrow   of scheme * typ * ceffect
+  | TLabel   of effct * typ * effct
+  | THandler of
+    { tvar    : tvar;
+      cap_tp  : typ;
+      in_tp   : typ;
+      in_eff  : effct;
+      out_tp  : typ;
+      out_eff : effct
+    }
+  | TEffect  of effct
+  | TApp     of typ * typ
+
+type ctor_decl =
+  { ctor_name        : string;
+    ctor_targs       : named_tvar list;
+    ctor_named       : named_scheme list;
+    ctor_arg_schemes : scheme list
+  }
+
+type constr = effct * effct
+
+val t_var         : tvar -> typ
+val t_arrow       : scheme -> typ -> ceffect -> typ
+val t_pure_arrow  : scheme -> typ -> typ
+val t_pure_arrows : scheme list -> typ -> typ
+val t_label       : effct -> typ -> effct -> typ
+val t_handler     : tvar -> typ -> typ -> effct -> typ -> effct -> typ
+val t_effect      : effct -> typ
+val t_app         : typ -> typ -> typ
+val t_apps        : typ -> typ list -> typ
+
+val view : typ -> type_view
+
+val to_effect : typ -> effct

--- a/src/Lang/ConEPriv/dune
+++ b/src/Lang/ConEPriv/dune
@@ -1,0 +1,3 @@
+(library
+  (name conEPriv)
+  (libraries utils incrSAT unifCommon))

--- a/src/Lang/UnifCommon/TVar.ml
+++ b/src/Lang/UnifCommon/TVar.ml
@@ -31,7 +31,8 @@ let fresh ?pp_uid ~scope kind =
     scope  = scope
   }
 
-let clone ~scope x = fresh ~scope (kind x)
+let clone ~scope x =
+  { x with uid = UID.fresh (); scope = scope }
 
 let equal x y = x == y
 

--- a/src/Lang/dune
+++ b/src/Lang/dune
@@ -1,3 +1,3 @@
 (library
   (name lang)
-  (libraries unifPriv corePriv utils))
+  (libraries unifPriv conEPriv corePriv utils))


### PR DESCRIPTION
This pull request introduces ConE intermediate language ­— the internal language of effect inference. In ConE, effects can be guarded by (positive) formulae of propositional logic, and from these formulae we generate clauses for a SAT-solver. For convenience, ConE shares the representation of propositional variables with the SAT-solver, which is also included in this PR.