### PR TITLE
Fixed bug in backtrackable references

### DIFF
--- a/src/IncrSAT/Solver.ml
+++ b/src/IncrSAT/Solver.ml
@@ -217,3 +217,15 @@ let solve_all solver =
       end
     end
   | err -> err
+
+(* ========================================================================= *)
+
+let lit_to_sexpr (x, pol) =
+  if pol then PropVar.to_sexpr x
+  else SExpr.List [ Sym "not"; PropVar.to_sexpr x ]
+
+let clause_to_sexpr cl =
+  SExpr.List (Sym "or" :: List.map lit_to_sexpr cl.lits)
+
+let clauses_to_sexpr solver =
+  List.map clause_to_sexpr (BRef.get solver.clauses)

--- a/src/IncrSAT/Solver.mli
+++ b/src/IncrSAT/Solver.mli
@@ -23,3 +23,6 @@ val solve_partial : 'a t -> 'a solve_result
 
 (** Solve all the collected clauses *)
 val solve_all : 'a t -> 'a solve_result
+
+(** Pretty print all clauses of the SAT-solver as S-expressions. *)
+val clauses_to_sexpr : 'a t -> SExpr.t list

--- a/src/Utils/BRef.ml
+++ b/src/Utils/BRef.ml
@@ -5,27 +5,32 @@
 (** Backtrackable references *)
 
 type world_state =
-| Active   (** State of new world -- can change to Commited or Invalid *)
-| Commited (** Commited world -- cannot change *)
-| Invalid  (** Invalid world -- cannot change, and values must backtrack *)
+  | Active    (** State of new world -- can change to Committed or Invalid *)
+  | Committed (** Committed world -- cannot change *)
+  | Invalid   (** Invalid world -- cannot change, and values must backtrack *)
 
-type world = world_state ref
+(** Worlds form a tree (with pointers towards the root) where nodes contain
+  mutable state of the world. *)
+type world =
+  | WRoot
+  | WNode of { mutable state : world_state; parent : world }
 
 type 'a parent =
-| PRoot
-| PSaved of
-  { value  : 'a
-  ; world  : world
-  ; parent : 'a parent
-  }
+  | PRoot
+  | PSaved of
+    { value  : 'a;
+      world  : world;
+      parent : 'a parent
+    }
 
 type 'a t =
-  { mutable value  : 'a
-  ; mutable world  : world
-  ; mutable parent : 'a parent
+  { mutable value  : 'a;
+    mutable world  : world;
+    mutable parent : 'a parent
   }
 
-let top_world = ref (ref Active)
+(** Current world *)
+let top_world = ref WRoot
 
 let create v =
   { value  = v
@@ -37,28 +42,36 @@ let equal r1 r2 = r1 == r2
 
 (** Backtrack if world of given reference is invalid *)
 let rec fix_world r =
-  match !(r.world) with
-  | Active   -> ()
-  | Commited ->
-    (* The world is commited, should propagate changes *)
-    begin match r.parent with
-    | PRoot -> () (* No other worlds to inform *)
-    | PSaved p ->
-      (* Collapse parent worlds *)
-      r.world  <- p.world;
-      r.parent <- p.parent;
-      fix_world r
+  match r.world with
+  | WRoot       -> ()
+  | WNode wnode ->
+    begin match wnode.state with
+    | Active    -> ()
+    | Committed ->
+      (* The world is committed, should propagate changes *)
+      propagate_commit wnode.parent r
+    | Invalid   ->
+      begin match r.parent with
+      | PRoot -> failwith "BRef: Use of value created in an invalid world"
+      | PSaved p ->
+        (* Backtrack and try again *)
+        r.value  <- p.value;
+        r.world  <- p.world;
+        r.parent <- p.parent;
+        fix_world r
+      end
     end
-  | Invalid ->
-    begin match r.parent with
-    | PRoot -> failwith "BRef: Use of value created in an invalid world"
-    | PSaved p  ->
-      (* Backtrack and try again *)
-      r.value  <- p.value;
-      r.world  <- p.world;
-      r.parent <- p.parent;
-      fix_world r
-    end
+
+and propagate_commit world r =
+  r.world <- world;
+  match r.parent with
+  | PSaved p when world == p.world ->
+    (* Saved value from parent world can be discarded, because the world was
+      committed. *)
+    r.parent <- p.parent;
+    fix_world r
+  | PRoot | PSaved _ ->
+    fix_world r
 
 let get r =
   fix_world r;
@@ -71,9 +84,9 @@ let rec set r v =
   else begin
     (* Save old value for potential backtracking *)
     r.parent <- PSaved
-      { value  = r.value
-      ; world  = r.world
-      ; parent = r.parent
+      { value  = r.value;
+        world  = r.world;
+        parent = r.parent
       };
     (* Set new value and world *)
     r.value <- v;
@@ -81,15 +94,21 @@ let rec set r v =
   end
 
 let bracket f =
-  let old_world = !top_world in
-  let new_world = ref Active in
-  top_world := new_world;
+  top_world := WNode { state = Active; parent = !top_world };
   match f () with
   | v ->
-    new_world := Commited;
-    top_world := old_world;
-    v
+    begin match !top_world with
+    | WRoot   -> assert false (* Stack discipline was violated. *)
+    | WNode w ->
+      w.state <- Committed;
+      top_world := w.parent;
+      v
+    end
   | exception ex ->
-    new_world := Invalid;
-    top_world := old_world;
-    raise ex
+    begin match !top_world with
+    | WRoot   -> assert false (* Stack discipline was violated. *)
+    | WNode w ->
+      w.state <- Invalid;
+      top_world := w.parent;
+      raise ex
+    end


### PR DESCRIPTION
Fixed bug in backtrackable references, that allowed changes from committed world to be visible in the active world, even if there is an invalid world in between. This commit fixes wrong behavior of REPL when user-defined handlers were installed during the REPL session.

Additionally, I added some `to_sexpr` functions to SAT-solver, that I implemented during the debugging process. I hope they might be useful in the future.