### PR TITLE
Printing location of unsolved unification variables

### DIFF
--- a/src/EffectInference/Error.ml
+++ b/src/EffectInference/Error.ml
@@ -129,6 +129,4 @@ let unused_pattern ~pos =
   (pos, "This pattern is unused")
 
 let unsolved_unification_variable ~pos =
-  InterpLib.Error.report ~pos ~cls:FatalError
-    "Unsolved unification variable left";
-  raise InterpLib.Error.Fatal_error
+  (pos, "Unsolved unification variable left")

--- a/src/EffectInference/Error.ml
+++ b/src/EffectInference/Error.ml
@@ -128,7 +128,7 @@ let non_exhaustive_match ~pos ctx =
 let unused_pattern ~pos =
   (pos, "This pattern is unused")
 
-let unsolved_unification_variable () =
-  InterpLib.Error.report ~cls:FatalError
+let unsolved_unification_variable ~pos =
+  InterpLib.Error.report ~pos ~cls:FatalError
     "Unsolved unification variable left";
   raise InterpLib.Error.Fatal_error

--- a/src/EffectInference/Error.mli
+++ b/src/EffectInference/Error.mli
@@ -21,4 +21,4 @@ val non_exhaustive_match : pos:Position.t -> PatternContext.ctx -> t
 
 val unused_pattern : pos:Position.t -> t
 
-val unsolved_unification_variable : unit -> t
+val unsolved_unification_variable : pos:Position.t -> t

--- a/src/EffectInference/Type.ml
+++ b/src/EffectInference/Type.ml
@@ -23,7 +23,7 @@ let rec tr_type env (tp : S.typ) =
 
     | _ ->
       (* TODO: we can handle them in the future. *)
-      Error.fatal (Error.unsolved_unification_variable ())
+      Error.fatal (Error.unsolved_unification_variable ~pos:(S.UVar.pos u))
     end
 
   | TVar x -> T.Type.t_var (Env.lookup_tvar env x)

--- a/src/Lang/Unif.mli
+++ b/src/Lang/Unif.mli
@@ -595,6 +595,9 @@ module UVar : sig
   (** Check if a unification variable can be used in a given scope *)
   val in_scope : t -> Scope.t -> bool
 
+  (** Get position of variable's first use *)
+  val pos : t -> Position.t
+
   (** Set of unification variables *)
   module Set : Set.S with type elt = t
 
@@ -720,7 +723,7 @@ module Type : sig
   val t_apps : typ -> typ list -> typ
 
   (** Fresh unification variable (packed as type) *)
-  val fresh_uvar : scope:Scope.t -> kind -> typ
+  val fresh_uvar : pos:Position.t -> scope:Scope.t -> kind -> typ
 
   (** Reveal a top-most constructor of a type *)
   val view : typ -> type_view

--- a/src/Lang/UnifPriv/Type.ml
+++ b/src/Lang/UnifPriv/Type.ml
@@ -9,7 +9,7 @@ open TypeBase
 
 let view = TypeBase.view
 
-let fresh_uvar ~scope kind = t_uvar (UVar.fresh ~scope kind)
+let fresh_uvar ~pos ~scope kind = t_uvar (UVar.fresh ~pos ~scope kind)
 
 let t_unit = t_var BuiltinType.tv_unit
 

--- a/src/Lang/UnifPriv/TypeBase.ml
+++ b/src/Lang/UnifPriv/TypeBase.ml
@@ -19,7 +19,8 @@ type uvar = {
   uid   : UID.t;
   kind  : kind;
   state : uvar_state BRef.t;
-  scope : Scope.t BRef.t
+  scope : Scope.t BRef.t;
+  pos   : Position.t
 }
 
 and uvar_state =
@@ -85,11 +86,12 @@ module UVar = struct
   end
   include Ordered
 
-  let fresh ~scope kind =
+  let fresh ~pos ~scope kind =
     { uid   = UID.fresh ();
       kind  = kind;
       state = BRef.create UV_UVar;
-      scope = BRef.create scope
+      scope = BRef.create scope;
+      pos   = pos
     }
 
   let kind u = u.kind
@@ -120,6 +122,8 @@ module UVar = struct
 
   let in_scope u scope =
     Scope.mem (BRef.get u.scope) scope
+
+  let pos u = u.pos
 
   module Set = Set.Make(Ordered)
   module Map = Map.Make(Ordered)

--- a/src/Lang/UnifPriv/TypeBase.mli
+++ b/src/Lang/UnifPriv/TypeBase.mli
@@ -79,7 +79,7 @@ val view : typ -> type_view
 module UVar : sig
   type t = uvar
 
-  val fresh : scope:Scope.t -> kind -> uvar
+  val fresh : pos:Position.t -> scope:Scope.t -> kind -> uvar
 
   (** Get the kind of given unification variable *)
   val kind : t -> kind
@@ -101,6 +101,9 @@ module UVar : sig
   val shrink_scope : t -> Scope.t -> unit
 
   val in_scope : t -> Scope.t -> bool
+
+  (** Get position of variables first use *)
+  val pos : t -> Position.t
 
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t

--- a/src/TypeInference/Env.ml
+++ b/src/TypeInference/Env.ml
@@ -306,5 +306,5 @@ let scope (Env env) = env.scope
 
 let pp_tree (Env env) = env.pp_tree
 
-let fresh_uvar (Env env) kind =
-  T.Type.fresh_uvar ~scope:env.scope kind
+let fresh_uvar ~pos (Env env) kind =
+  T.Type.fresh_uvar ~pos ~scope:env.scope kind

--- a/src/TypeInference/Env.mli
+++ b/src/TypeInference/Env.mli
@@ -157,4 +157,4 @@ val scope : 'st t -> Scope.t
 val pp_tree : 'st t -> PPTree.t
 
 (** Create a fresh unification variable in the current scope *)
-val fresh_uvar : 'st t -> T.kind -> T.typ
+val fresh_uvar : pos:Position.t -> 'st t -> T.kind -> T.typ

--- a/src/TypeInference/Expr.ml
+++ b/src/TypeInference/Expr.ml
@@ -209,8 +209,6 @@ let rec check_repl_def_seq ~tcfix env def_seq tp =
           match tp_req with
           | Check tp -> (tp, Checked)
           | Infer    ->
-            (* This probably can be something more than nowhere,
-                but will require significant refactor *)
             let tp = Env.fresh_uvar ~pos:Position.nowhere env T.Kind.k_type in
             (tp, Infered tp)
         in
@@ -224,7 +222,6 @@ let rec check_repl_def_seq ~tcfix env def_seq tp =
       ConstrSolve.solve_all er.er_constr;
       er.er_expr
   in
-  (* Same here *)
   { T.pos  = Position.nowhere;
     T.pp   = Env.pp_tree env;
     T.data = T.ERepl(InterpLib.Error.wrap_repl_cont func, tp)

--- a/src/TypeInference/Expr.ml
+++ b/src/TypeInference/Expr.ml
@@ -26,7 +26,7 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
   let make data = T.{ pos; pp; data } in
   match e.data with
   | EMatch _ | EEffect _ | EExtern _ | ERepl _ ->
-    let tp = Env.fresh_uvar env T.Kind.k_type in
+    let tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     let er = check_expr_type env e tp in
     { er with er_type = Infered tp }
 
@@ -71,7 +71,7 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
       (Inst.instantiate_poly_expr ~tcfix ~pos env e sch inst)
 
   | EFn(pat, body) ->
-    let tp2 = Env.fresh_uvar env T.Kind.k_type in
+    let tp2 = Env.fresh_uvar ~pos:body.pos env T.Kind.k_type in
     let (env, pat, sch_expr, eff1) = Pattern.infer_scheme_ext env pat in
     let sch = T.SchemeExpr.to_scheme sch_expr in
     let er_body = check_expr_type env body tp2 in
@@ -86,7 +86,7 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
   | EApp(e1, e2) ->
     let er1 = infer_expr_type ?app_type env e1 in
     let ftp = expr_result_type er1 in
-    begin match Unification.to_arrow env ftp with
+    begin match Unification.to_arrow ~pos:e1.pos env ftp with
     | Arr_UVar -> assert false
     | Arr_Arrow(sch, tp2, eff) ->
       begin match PolyExpr.check_def_scheme ~tcfix env e2 sch with
@@ -116,11 +116,10 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
       }
 
   | EHandler(cap, rcs, fcs) ->
-    let fin_tp = Env.fresh_uvar env T.Kind.k_type in
     (* TODO: effect and label could be named here *)
     let (env, _) = Env.enter_scope env in
     let (env, a) = Env.add_anon_tvar ~pos ~name:"E" env T.Kind.k_effect in
-    let delim_tp = Env.fresh_uvar env T.Kind.k_type in
+    let delim_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     let (env, lx) = Env.add_the_label env (T.Type.t_label delim_tp) in
     let er_cap = infer_expr_type env cap in
     begin match er_cap.er_effect with
@@ -128,7 +127,8 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
     | Impure -> Error.report (Error.impure_handler ~pos)
     end;
     let cap_tp = expr_result_type er_cap in
-    let body_tp = Env.fresh_uvar env T.Kind.k_type in
+    let body_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
+    let fin_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     let (ret_x, er_ret) =
       MatchClause.tr_return_clauses ~tcfix ~pos env body_tp rcs
         (Check delim_tp) in
@@ -180,7 +180,7 @@ let check_label ~tcfix ~pos env lbl_opt =
       end
   in
   let delim_tp =
-    match Unification.to_label env lbl_tp with
+    match Unification.to_label ~pos env lbl_tp with
     | L_Label delim_tp -> delim_tp
     | L_No ->
       let pp = Env.pp_tree env in
@@ -190,7 +190,7 @@ let check_label ~tcfix ~pos env lbl_opt =
       | None ->
         Error.report (Error.wrong_label_type ~pos ~pp lbl_tp)
       end;
-      Env.fresh_uvar env T.Kind.k_type
+      Env.fresh_uvar ~pos env T.Kind.k_type
   in
   (lbl, delim_tp, cs)
 
@@ -209,7 +209,9 @@ let rec check_repl_def_seq ~tcfix env def_seq tp =
           match tp_req with
           | Check tp -> (tp, Checked)
           | Infer    ->
-            let tp = Env.fresh_uvar env T.Kind.k_type in
+            (* This probably can be something more than nowhere,
+                but will require significant refactor *)
+            let tp = Env.fresh_uvar ~pos:Position.nowhere env T.Kind.k_type in
             (tp, Infered tp)
         in
         { er_expr   = check_repl_def_seq ~tcfix env def_seq tp;
@@ -222,6 +224,7 @@ let rec check_repl_def_seq ~tcfix env def_seq tp =
       ConstrSolve.solve_all er.er_constr;
       er.er_expr
   in
+  (* Same here *)
   { T.pos  = Position.nowhere;
     T.pp   = Env.pp_tree env;
     T.data = T.ERepl(InterpLib.Error.wrap_repl_cont func, tp)
@@ -327,7 +330,7 @@ let check_expr_type ~tcfix env (e : S.expr) tp =
     }
 
   | EHandler(cap, rcs, fcs) ->
-    begin match Unification.from_handler env tp with
+    begin match Unification.from_handler ~pos env tp with
     | H_Handler(b, cap_tp, tp_in, tp_out) ->
       (* TODO: effect and label could be named here *)
       let (env, scope) = Env.enter_scope env in
@@ -335,7 +338,7 @@ let check_expr_type ~tcfix env (e : S.expr) tp =
       let sub = T.Subst.rename_tvar (T.Subst.empty ~scope) b a in
       let cap_tp = T.Type.subst sub cap_tp in
       let tp_in  = T.Type.subst sub tp_in in
-      let delim_tp = Env.fresh_uvar env T.Kind.k_type in
+      let delim_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
       let (env, lx) = Env.add_the_label env (T.Type.t_label delim_tp) in
       let er_cap = check_expr_type env cap cap_tp in
       begin match er_cap.er_effect with

--- a/src/TypeInference/Inst.ml
+++ b/src/TypeInference/Inst.ml
@@ -137,14 +137,14 @@ let build_type_params ~pos ~env insts sch_targs =
   let build_type_param sub (name, x) =
     match name with
     | T.TNAnon ->
-      let tp = Env.fresh_uvar env (T.TVar.kind x) in
+      let tp = Env.fresh_uvar ~pos env (T.TVar.kind x) in
       let tp_expr = make (T.TE_Type tp) in
       (T.Subst.add_type sub x tp, tp_expr)
 
     | T.TNVar name ->
       begin match StrMap.find_opt name insts with
       | None ->
-        let tp = Env.fresh_uvar env (T.TVar.kind x) in
+        let tp = Env.fresh_uvar ~pos env (T.TVar.kind x) in
         let tp_expr = make (T.TE_Type tp) in
         (T.Subst.add_type sub x tp, tp_expr)
 

--- a/src/TypeInference/MatchClause.ml
+++ b/src/TypeInference/MatchClause.ml
@@ -26,11 +26,11 @@ let check_match_clauses ~tcfix env tp cls res_tp =
   let ((eff, cs), cls) = List.fold_left_map check (T.Pure, []) cls in
   (cls, eff, cs)
 
-let guess_type (type d) env (req : (_, d) request) : _ * (_, d) response =
+let guess_type (type d) ~pos env (req : (_, d) request) : _ * (_, d) response =
   match req with
   | Check tp -> (tp, Checked)
   | Infer    ->
-    let tp = Env.fresh_uvar env T.Kind.k_type in
+    let tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     (tp, Infered tp)
 
 let tr_opt_clauses (type dir) ~tcfix ~pos env tp_in cls
@@ -61,7 +61,7 @@ let tr_opt_clauses (type dir) ~tcfix ~pos env tp_in cls
     in (x, er)
 
   | _ :: _, _ ->
-    let (tp, tp_resp) = guess_type env rtp_req in
+    let (tp, tp_resp) = guess_type ~pos env rtp_req in
     let (cls, eff, cs) = check_match_clauses ~tcfix env tp_in cls tp in
     let er =
       { er_expr   = make (T.EMatch(x_expr, cls, tp, eff));

--- a/src/TypeInference/ParamEnv.ml
+++ b/src/TypeInference/ParamEnv.ml
@@ -195,7 +195,7 @@ let open_param_decl ~new_scope (env, tps, vps, tmap) decl =
     let sub =
       List.fold_left
         (fun sub x ->
-          let tp = T.Type.fresh_uvar ~scope:new_scope (T.TVar.kind x) in
+          let tp = T.Type.fresh_uvar ~pos ~scope:new_scope (T.TVar.kind x) in
           T.Subst.add_type sub x tp)
         sub
         free_types

--- a/src/TypeInference/ParamResolve.ml
+++ b/src/TypeInference/ParamResolve.ml
@@ -124,7 +124,7 @@ let open_scheme_explicit ~pos env (sch : T.scheme) =
   variables. *)
 let guess_types ~pos env targs =
   let guess_type sub (_, x) =
-    let tp = Env.fresh_uvar env (T.TVar.kind x) in
+    let tp = Env.fresh_uvar ~pos env (T.TVar.kind x) in
     let tp_expr = { T.pos; T.pp = Env.pp_tree env; T.data = T.TE_Type tp } in
     (T.Subst.add_type sub x tp, tp_expr)
   in

--- a/src/TypeInference/Pattern.ml
+++ b/src/TypeInference/Pattern.ml
@@ -370,7 +370,7 @@ and check_named_pattern env np tvars named =
 let infer_scheme env (pat : S.pattern) =
   match pat.data with
   | PWildcard | PId _ | PCtor _ ->
-    let tp = Env.fresh_uvar env T.Kind.k_type in
+    let tp = Env.fresh_uvar ~pos:pat.pos env T.Kind.k_type in
     let tp_expr =
       { T.pos  = pat.pos;
         T.pp   = Env.pp_tree env;
@@ -426,7 +426,7 @@ let infer_named_pattern env (np : S.named_pattern) =
       | None ->
         { T.pos  = np.pos;
           T.pp   = Env.pp_tree env;
-          T.data = T.TE_Type (Env.fresh_uvar env T.Kind.k_type)
+          T.data = T.TE_Type (Env.fresh_uvar ~pos:np.pos env T.Kind.k_type)
         }
     in
     let sch_expr = BuiltinTypes.mk_option_scheme_expr tp_expr in

--- a/src/TypeInference/PolyExpr.ml
+++ b/src/TypeInference/PolyExpr.ml
@@ -201,7 +201,7 @@ let infer_def_scheme ~tcfix env (e : S.poly_expr_def) =
   | PE_Fn(pats, body) ->
     let (env, scope, targs, named, eff) =
       Pattern.infer_named_patterns_ext env pats in
-    let body_tp = T.Type.fresh_uvar ~scope T.Kind.k_type in
+    let body_tp = T.Type.fresh_uvar ~pos:body.pos ~scope T.Kind.k_type in
     let body = check_expr_type env body body_tp in
     let eff = T.Effect.join eff body.er_effect in
     begin match eff with

--- a/src/TypeInference/Type.ml
+++ b/src/TypeInference/Type.ml
@@ -22,8 +22,8 @@ let rec infer_kind env (tp : S.type_expr) =
   match tp.data with
   | TWildcard ->
     let k = T.Kind.fresh_uvar () in
-    (make (T.TE_Type(Env.fresh_uvar env k)), k)
-  
+    (make (T.TE_Type(Env.fresh_uvar ~pos env k)), k)
+
   | TVar path ->
     let tp = ModulePath.lookup_type env path in
     (make (T.TE_Type tp), T.Type.kind tp)

--- a/src/TypeInference/Unification.ml
+++ b/src/TypeInference/Unification.ml
@@ -238,11 +238,11 @@ let subscheme env sch1 sch2 =
   | exception Error -> Unify_Fail []
   | exception Escapes_scope(env, tv) -> Unify_Fail [TVarEscapesScope(env, tv)]
 
-let to_arrow env tp =
+let to_arrow ~pos env tp =
   match T.Type.view tp with
   | TUVar u ->
-    let sch = T.Scheme.of_type (Env.fresh_uvar env T.Kind.k_type) in
-    let tp2 = Env.fresh_uvar env T.Kind.k_type in
+    let sch = T.Scheme.of_type (Env.fresh_uvar ~pos env T.Kind.k_type) in
+    let tp2 = Env.fresh_uvar ~pos env T.Kind.k_type in
     set_uvar env u (T.Type.t_arrow sch tp2 Impure);
     Arr_Arrow(sch, tp2, Impure)
 
@@ -263,14 +263,14 @@ let from_arrow env tp =
   | TEffect ->
     failwith "Internal kind error"
 
-let to_handler env tp =
+let to_handler ~pos env tp =
   match T.Type.view tp with
   | TUVar u ->
     let (env1, _) = Env.enter_scope env in
     let (_, a) = Env.add_anon_tvar env1 T.Kind.k_effect in
-    let cap_tp = Env.fresh_uvar env T.Kind.k_type in
-    let tp_in  = Env.fresh_uvar env T.Kind.k_type in
-    let tp_out = Env.fresh_uvar env T.Kind.k_type in
+    let cap_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
+    let tp_in  = Env.fresh_uvar ~pos env T.Kind.k_type in
+    let tp_out = Env.fresh_uvar ~pos env T.Kind.k_type in
     set_uvar env u (T.Type.t_handler a cap_tp tp_in tp_out);
     H_Handler(a, cap_tp, tp_in, tp_out)
 
@@ -282,14 +282,14 @@ let to_handler env tp =
   | TEffect ->
     failwith "Internal kind error"
 
-let from_handler env tp =
+let from_handler ~pos env tp =
   match T.Type.view tp with
   | TUVar u ->
     let (env1, _) = Env.enter_scope env in
     let (_, a) = Env.add_anon_tvar env1 T.Kind.k_effect in
-    let cap_tp = Env.fresh_uvar env T.Kind.k_type in
-    let tp_in  = Env.fresh_uvar env T.Kind.k_type in
-    let tp_out = Env.fresh_uvar env T.Kind.k_type in
+    let cap_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
+    let tp_in  = Env.fresh_uvar ~pos env T.Kind.k_type in
+    let tp_out = Env.fresh_uvar ~pos env T.Kind.k_type in
     set_uvar env u (T.Type.t_handler a cap_tp tp_in tp_out);
     H_Handler(a, cap_tp, tp_in, tp_out)
 
@@ -301,10 +301,10 @@ let from_handler env tp =
   | TEffect ->
     failwith "Internal kind error"
 
-let to_label env tp =
+let to_label ~pos env tp =
   match T.Type.view tp with
   | TUVar u ->
-    let tp0 = Env.fresh_uvar env T.Kind.k_type in
+    let tp0 = Env.fresh_uvar ~pos env T.Kind.k_type in
     set_uvar env u (T.Type.t_label tp0);
     L_Label tp0
 

--- a/src/TypeInference/Unification.mli
+++ b/src/TypeInference/Unification.mli
@@ -68,7 +68,7 @@ val subscheme : 'st Env.t -> T.scheme -> T.scheme -> result
 
 (** Coerce given type to an arrow.
   It performs some unifications when necessary. Never returns [Arr_UVar]. *)
-val to_arrow : 'st Env.t -> T.typ -> arrow
+val to_arrow : pos:Position.t -> 'st Env.t -> T.typ -> arrow
 
 (** Coerce given type from an arrow.
   It performs some unifications when necessary. Returns [Arr_UVar], when given
@@ -77,12 +77,12 @@ val from_arrow : 'st Env.t -> T.typ -> arrow
 
 (** Coerce given type to a handler.
   It performs some unification when necessary. *)
-val to_handler : 'st Env.t -> T.typ -> handler
+val to_handler : pos:Position.t -> 'st Env.t -> T.typ -> handler
 
 (** Coerce given type from a handler.
   It performs some unification when necessary. *)
-val from_handler : 'st Env.t -> T.typ -> handler
+val from_handler : pos:Position.t -> 'st Env.t -> T.typ -> handler
 
 (** Coerce given type to a label type.
   It performs some unification when necessary. *)
-val to_label : 'st Env.t -> T.typ -> label
+val to_label : pos:Position.t -> 'st Env.t -> T.typ -> label

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -95,16 +95,18 @@ let join_sorted p1 p2 =
   and pos_length = abs (p2.pos_start_cnum - p1.pos_start_cnum)
     + max p1.pos_length p2.pos_length
   and pos_fname = p1.pos_fname
-  in
-  { pos_fname; pos_start_line; pos_start_cnum; pos_start_bol
-  ; pos_length; pos_end_line; pos_end_bol }
+  in { pos_fname; pos_start_line; pos_start_cnum
+  ; pos_start_bol; pos_length; pos_end_line; pos_end_bol }
 
 (** Join list of positions into single one.
   It take file name the head of the list and join the rest.
   Returns Position.nowhere for empty list *)
-let join_list = function
+let join_list f xs =
+  match xs with
   | [] -> nowhere
-  | p1 :: ps -> List.fold_left join_sorted p1 ps
+  | p1 :: ps ->
+    let h acc a = join_sorted acc (f a) in
+    List.fold_left h (f p1) ps
 
 (** Get the number of the first column of the position (counting from 1) *)
 let start_column pos =

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -62,7 +62,7 @@ let of_lexing len (p : Lexing.position) =
   ; pos_end_bol    = p.pos_bol
   }
 
-(** Join to position into single one.
+(** Join two positions into single one.
   It take file name and start from the first parameter and end from the second
   parameter *)
 let join p1 p2 =
@@ -74,6 +74,37 @@ let join p1 p2 =
   ; pos_end_line   = p2.pos_end_line
   ; pos_end_bol    = p2.pos_end_bol
   }
+
+let join_sorted p1 p2 =
+  let pos_start_line, pos_start_cnum, pos_start_bol =
+    if p1.pos_start_line < p2.pos_start_line then
+      p1.pos_start_line, p1.pos_start_cnum, p1.pos_start_bol
+    else if p1.pos_start_line > p2.pos_start_line then
+      p2.pos_start_line, p2.pos_start_cnum, p2.pos_start_bol
+    else if p1.pos_start_line < p2.pos_start_line then
+      p1.pos_start_line, p1.pos_start_cnum, p1.pos_start_bol
+    else p2.pos_start_line, p2.pos_start_cnum, p2.pos_start_bol
+  and pos_end_line, pos_end_bol =
+    if p1.pos_end_line > p2.pos_end_line then
+      p1.pos_end_line, p1.pos_end_bol
+    else if p1.pos_end_line < p2.pos_end_line then
+      p2.pos_end_line, p2.pos_end_bol
+    else if p1.pos_end_line > p2.pos_end_line then
+      p1.pos_end_line, p1.pos_end_bol
+    else p2.pos_end_line, p2.pos_end_bol
+  and pos_length = abs (p2.pos_start_cnum - p1.pos_start_cnum)
+    + max p1.pos_length p2.pos_length
+  and pos_fname = p1.pos_fname
+  in
+  { pos_fname; pos_start_line; pos_start_cnum; pos_start_bol
+  ; pos_length; pos_end_line; pos_end_bol }
+
+(** Join list of positions into single one.
+  It take file name the head of the list and join the rest.
+  Returns Position.nowhere for empty list *)
+let join_list = function
+  | [] -> nowhere
+  | p1 :: ps -> List.fold_left join_sorted p1 ps
 
 (** Get the number of the first column of the position (counting from 1) *)
 let start_column pos =

--- a/src/Utils/Position.ml
+++ b/src/Utils/Position.ml
@@ -75,39 +75,6 @@ let join p1 p2 =
   ; pos_end_bol    = p2.pos_end_bol
   }
 
-let join_sorted p1 p2 =
-  let pos_start_line, pos_start_cnum, pos_start_bol =
-    if p1.pos_start_line < p2.pos_start_line then
-      p1.pos_start_line, p1.pos_start_cnum, p1.pos_start_bol
-    else if p1.pos_start_line > p2.pos_start_line then
-      p2.pos_start_line, p2.pos_start_cnum, p2.pos_start_bol
-    else if p1.pos_start_line < p2.pos_start_line then
-      p1.pos_start_line, p1.pos_start_cnum, p1.pos_start_bol
-    else p2.pos_start_line, p2.pos_start_cnum, p2.pos_start_bol
-  and pos_end_line, pos_end_bol =
-    if p1.pos_end_line > p2.pos_end_line then
-      p1.pos_end_line, p1.pos_end_bol
-    else if p1.pos_end_line < p2.pos_end_line then
-      p2.pos_end_line, p2.pos_end_bol
-    else if p1.pos_end_line > p2.pos_end_line then
-      p1.pos_end_line, p1.pos_end_bol
-    else p2.pos_end_line, p2.pos_end_bol
-  and pos_length = abs (p2.pos_start_cnum - p1.pos_start_cnum)
-    + max p1.pos_length p2.pos_length
-  and pos_fname = p1.pos_fname
-  in { pos_fname; pos_start_line; pos_start_cnum
-  ; pos_start_bol; pos_length; pos_end_line; pos_end_bol }
-
-(** Join list of positions into single one.
-  It take file name the head of the list and join the rest.
-  Returns Position.nowhere for empty list *)
-let join_list f xs =
-  match xs with
-  | [] -> nowhere
-  | p1 :: ps ->
-    let h acc a = join_sorted acc (f a) in
-    List.fold_left h (f p1) ps
-
 (** Get the number of the first column of the position (counting from 1) *)
 let start_column pos =
   pos.pos_start_cnum - pos.pos_start_bol + 1


### PR DESCRIPTION
Before getting `Unsolved unification variable left` meant walking in the dark trying to figure, where this error came from.
Now when seeing this error it will be accompanied by location where the unification variable was created:
```
fatal error: Unsolved unification variable left
 -> test1.fram
 1 | let id a = a
 2 |>let _ = id
   |         ^^
```