### PR TITLE
Fixed newlines in multiline strings

### DIFF
--- a/src/DblParser/Lexer.mll
+++ b/src/DblParser/Lexer.mll
@@ -190,7 +190,7 @@ and string_token pos buf = parse
       lexbuf.Lexing.lex_start_p <- pos;
       YaccParser.STR (Buffer.contents buf)
     }
-  | [^'"' '\\']+ as str {
+  | [^'"' '\\' '\n']+ as str {
       Buffer.add_string buf str;
       string_token pos buf lexbuf
     }


### PR DESCRIPTION
A really simple fix to multiline strings.

Fixes #234 