### PR TITLE
Recurse correctly on ERecCtx

### DIFF
--- a/src/Lang/CorePriv/SExprPrinter.ml
+++ b/src/Lang/CorePriv/SExprPrinter.ml
@@ -188,7 +188,7 @@ and tr_defs (e : Syntax.expr) =
     List [Sym "let-irr"; tr_var x; tr_expr e1] :: tr_defs e2
   | ELetRec(rds, e2) ->
     List (Sym "let-rec" :: List.map tr_rec_def rds) :: tr_defs e2
-  | ERecCtx _ ->
+  | ERecCtx e ->
     List [Sym "rec-ctx"] :: tr_defs e
   | EData(dds, e2) ->
     List (Sym "data" :: List.map tr_data_def dds) :: tr_defs e2


### PR DESCRIPTION
Fixes #246.
Fixes a bug where `CorePriv/SExprPrinter.tr_defs` would not recurse properly on `ERecCtx`, instead falling into an infinite loop.

The question is, should this be tested? Currently, we don't test `-dcore` and `-dcone` flags anywhere in the suite, so I didn't add any tests confirming my fix. 
