### PR TITLE
Mutable lib additions revived

### DIFF
--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -473,8 +473,8 @@ pub method exists (self : ConstArray _) f =
 pub method forall (self : ConstArray _) f =
   not (self.exists (fn x => (not (f x)) ))
 
-{## Create a new array from mapped elements of a const array.
-  `arr.map f` creates a new const array consisiting of elements (f x) where x are elements of arr. f must be pure.
+{## Create a new immutable array from mapped elements of an immutable array.
+  `arr.map f` creates a new immutable array consisiting of elements (f x) where x are elements of arr. f must be pure.
 ##}
 pub method map (self : ConstArray _) (f : _ ->[] _)=
   pureInitConstArray self.length

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -301,15 +301,10 @@ pub method concatenate {E} (self : Array E _) (other : Array E _) =
 ##}
 pub method reverse {E} (self: Array E _) =
   let n = self.length in
-  let result = unsafeMakeArray {E} n in
-  let rec loopset (i: Int) =
-    if i >= n then ()
-    else (
-      result.at (n - (i + 1)) := (unsafeGetArray {E} self i);
-      loopset (i + 1) )
-  in
-  loopset 0;
-  result
+  unsafeInitArray {E} n
+  (
+    fn i => (unsafeGetArray{E} self (n-(i+1) ) )
+  )
 
 {## Check if any element of an array satisfies a condition.
   `a.exists f` returns `True` if function `f` returns `True` on any element of an array `a`,

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -311,7 +311,7 @@ pub method reverse {E, self: Array E _} =
   loopset 0;
   result
 
-{## Check if any element of an array satisfy a condition.
+{## Check if any element of an array satisfies a condition.
   `a.exists f` returns `True` if function `f` returns `True` on any element of an array `a`,
    otherwise it returns `False`
 ##}
@@ -321,6 +321,13 @@ pub method exists {E, self : Array E _} f =
     else (f (unsafeGetArray {E} self i)) || loop (i + 1)
   in
   loop 0
+
+{## Check if all elements of an array satisfy a condition.
+  `a.forall f` returns `False` if function `f` returns `False` on any element of the array `a`,
+  otherwise it returns `True`
+##}
+pub method forall {E, self: Array E_} f =
+  not (self.exists (not f))
 
 {# ========================================================================= #}
 ## ## Immutable arrays

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -459,3 +459,9 @@ pub method exists {E, self : ConstArray _} f =
     else (f (unsafeGetConstArray self i)) || loop (i + 1)
   in
   loop 0
+{## Check if all elements of an immutable array satisfy a condition.
+  `a.forall f` returns `False` if function `f` returns `False` on any element of the array `a`,
+  otherwise it returns `True`
+##}
+pub method forall {E, self : ConstArray _ } f =
+  not (self.exists (not f))

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -270,9 +270,9 @@ pub method foldLeft {E} (self : Array E _) f init =
   loop 0 init
 
 {## Map a function over an array.
- `arr.map f` maps function `f` over array `arr`
+ `arr.map_inplace f` maps function `f` over array `arr`
 ##}
-pub method map {E} (self : Array E _) f =
+pub method map_inplace {E} (self : Array E _) f =
   let rec loop (i: Int) =
     if i >= self.length then ()
     else (
@@ -280,6 +280,17 @@ pub method map {E} (self : Array E _) f =
       loop (i + 1))
   in
   loop 0
+
+{## Create a new array from mapped elements of an array.
+  `arr.map f` creates a new array consisiting of elements (f x) where x are elements of arr.
+  f must be pure.
+##}
+pub method map {E} (self : Array E _) (f : _ ->[] _)=
+  unsafeInitArray {E} self.length
+  (
+    fn i =>
+    (f (unsafeGetArray {E} self i))
+  )
 
 {## Concatenate two arrays.
   `a.concat b` returns new array with elements from `a` followed by elements from `b`
@@ -461,3 +472,13 @@ pub method exists (self : ConstArray _) f =
 ##}
 pub method forall (self : ConstArray _) f =
   not (self.exists (fn x => (not (f x)) ))
+
+{## Create a new array from mapped elements of a const array.
+  `arr.map f` creates a new const array consisiting of elements (f x) where x are elements of arr. f must be pure.
+##}
+pub method map (self : ConstArray _) (f : _ ->[] _)=
+  pureInitConstArray self.length
+  (
+    fn i =>
+    (f (self.get i))
+  )

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -252,7 +252,7 @@ pub method iter {E} (self : Array E _) f =
 {## Perform right fold on array.
   `a.foldRight f init [a1, a2, ..., an]` is equivalent to `f a1 (f a2 (... (f an init) ...))` 
 ##}
-pub method foldRight {E, self : Array E _} f init =
+pub method foldRight {E} (self : Array E _) f init =
   let rec loop (i : Int) =
     if i >= self.length then init
     else f (unsafeGetArray {E} self i) (loop (i + 1))
@@ -262,7 +262,7 @@ pub method foldRight {E, self : Array E _} f init =
 {## Perform left fold on array.
   `a.foldLeft f init [a1, a2, ..., an]` is equivalent to `f (... (f (f init a1) a2) ...) an` 
 ##}
-pub method foldLeft {E, self : Array E _} f init =
+pub method foldLeft {E} (self : Array E _) f init =
   let rec loop (i: Int) acc = 
     if i >= self.length then acc
     else loop (i + 1) (f acc (unsafeGetArray {E} self i))
@@ -272,7 +272,7 @@ pub method foldLeft {E, self : Array E _} f init =
 {## Map a function over an array.
  `arr.map f` maps function `f` over array `arr`
 ##}
-pub method map {E, self : Array E _} f =
+pub method map {E} (self : Array E _) f =
   let rec loop (i: Int) =
     if i >= self.length then ()
     else (
@@ -284,7 +284,7 @@ pub method map {E, self : Array E _} f =
 {## Concatenate two arrays.
   `a.concatenate b` returns new array with elements from `a` followed by elements from `b`
 ##}
-pub method concatenate {E, self : Array E _} (other : Array E _) =
+pub method concatenate {E} (self : Array E _) (other : Array E _) =
   let result = unsafeMakeArray {E} (self.length + other.length)
   let rec loopset (i: Int) (j: Int) (source : Array E _) =
     if i >= source.length then ()
@@ -299,7 +299,7 @@ pub method concatenate {E, self : Array E _} (other : Array E _) =
 {## Reverse an array.
   `a.reverse` returns new array with elements in reversed order
 ##}
-pub method reverse {E, self: Array E _} =
+pub method reverse {E} (self: Array E _) =
   let n = self.length in
   let result = unsafeMakeArray {E} n in
   let rec loopset (i: Int) =
@@ -315,7 +315,7 @@ pub method reverse {E, self: Array E _} =
   `a.exists f` returns `True` if function `f` returns `True` on any element of an array `a`,
    otherwise it returns `False`
 ##}
-pub method exists {E, self : Array E _} f =
+pub method exists {E} (self : Array E _) f =
   let rec loop (i: Int) =
     if i >= self.length then False
     else (f (unsafeGetArray {E} self i)) || loop (i + 1)
@@ -326,8 +326,8 @@ pub method exists {E, self : Array E _} f =
   `a.forall f` returns `False` if function `f` returns `False` on any element of the array `a`,
   otherwise it returns `True`
 ##}
-pub method forall {E, self: Array E_} f =
-  not (self.exists (not f))
+pub method forall {E} (self : Array E _) f =
+  not (self.exists (fn x => (not (f x)) ))
 
 {# ========================================================================= #}
 ## ## Immutable arrays
@@ -453,15 +453,16 @@ pub method foldLeft {self : ConstArray  _} f init =
   `a.exists f` returns `True` if function `f` returns `True` on any element of an immutable array `a`,
    otherwise it returns `False`
 ##}
-pub method exists {E, self : ConstArray _} f =
+pub method exists (self : ConstArray _) f =
   let rec loop (i: Int) =
     if i >= self.length then False
     else (f (unsafeGetConstArray self i)) || loop (i + 1)
   in
   loop 0
+
 {## Check if all elements of an immutable array satisfy a condition.
   `a.forall f` returns `False` if function `f` returns `False` on any element of the array `a`,
   otherwise it returns `True`
 ##}
-pub method forall {E, self : ConstArray _ } f =
-  not (self.exists (not f))
+pub method forall (self : ConstArray _) f =
+  not (self.exists (fn x => (not (f x)) ))

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -427,7 +427,7 @@ pub method iter (self : ConstArray _) f =
 {## Perform right fold on immutable array.
   `a.foldRight f init [a1, a2, ..., an]` is equivalent to `f a1 (f a2 (... (f an init) ...))` 
 ##}
-pub method foldRight {self : ConstArray _} f init =
+pub method foldRight (self : ConstArray _) f init =
   let rec loop (i : Int) =
     if i >= self.length then init
     else f (unsafeGetConstArray self i) (loop (i + 1))
@@ -437,7 +437,7 @@ pub method foldRight {self : ConstArray _} f init =
 {## Perform left fold on immutable array.
   `a.foldLeft f init [a1, a2, ..., an]` is equivalent to `f (... (f (f init a1) a2) ...) an` 
 ##}
-pub method foldLeft {self : ConstArray  _} f init =
+pub method foldLeft (self : ConstArray  _) f init =
   let rec loop (i: Int) acc = 
     if i >= self.length then acc
     else loop (i + 1) (f acc (unsafeGetConstArray self i))

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -282,19 +282,19 @@ pub method map {E} (self : Array E _) f =
   loop 0
 
 {## Concatenate two arrays.
-  `a.concatenate b` returns new array with elements from `a` followed by elements from `b`
+  `a.concat b` returns new array with elements from `a` followed by elements from `b`
 ##}
-pub method concatenate {E} (self : Array E _) (other : Array E _) =
-  let result = unsafeMakeArray {E} (self.length + other.length)
-  let rec loopset (i: Int) (j: Int) (source : Array E _) =
-    if i >= source.length then ()
-    else (
-      result.at j := (unsafeGetArray {E} source i);
-      loopset (i + 1) (j + 1) source)
-  in
-  loopset 0 0 self;
-  loopset 0 (self.length) other;
-  result
+pub method concat {E} (self: Array E _ ) (other : Array E _) =
+  let a = self.length in
+  let b = other.length in
+  unsafeInitArray {E} (a+b) 
+  (
+    fn i =>
+    if i< a then
+      (unsafeGetArray {E} self i)
+    else
+      (unsafeGetArray {E} other (i-a))
+  )
 
 {## Reverse an array.
   `a.reverse` returns new array with elements in reversed order

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -126,7 +126,7 @@ let testarr = [1,2].toArray {~mut=ioMut}
 let testarr2 = [3,4].toArray {~mut=ioMut}
 let lst = ca.toList
 let lst2 = testarr.toList
-let process = testarr.map (fn x => x+1)
+let process = testarr.map_inplace (fn x => x+1)
 let testarr3 = testarr.concat testarr2
 
 let testarr4 = testarr2.reverse
@@ -151,9 +151,12 @@ let _ =
 
 let arr0 = [4, 5, 6].toArray {~mut=ioMut}
 let ca2 = arr0.freeze
-
+let arr1 = arr0.map (fn x=> x+1)
+let ca3 = ca2.map (fn x=> x+1)
 let _ =
   assert((ca2.foldLeft (fn a x => a-x) 0)==(-15));
   assert((ca2.foldRight (fn x a => a-x) 0)==(-15));
+  assert((arr1.foldLeft (fn a x => a-x) 0)== (-18));
+  assert((ca3.foldLeft (fn a x => a-x) 0)== (-18));
   ()
 

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -150,3 +150,11 @@ let _ =
   assert((testarr3.foldLeft (fn a x => a+x) 0)==12);
   ()
 
+let arr0 = [4, 5, 6].toArray {~mut=ioMut}
+let ca2 = arr0.freeze
+
+let _ =
+  assert((ca2.foldLeft (fn a x => a-x) 0)==(-15));
+  assert((ca2.foldRight (fn x a => a-x) 0)==(-15));
+  ()
+

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -146,5 +146,6 @@ let _ =
   assert((ca.exists (fn x => x<0))==False);
   assert((ca.forall (fn x => x>1))==False);
   assert((testarr4.get 0)==4);
+  assert((testarr4.get 1)==3);
   ()
 

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -128,7 +128,7 @@ let testarr2 = [3,4].toArray {~mut=ioMut}
 let lst = ca.toList
 let lst2 = testarr.toList
 let process = testarr.map (fn x => x+1)
-let testarr3 = testarr.concatenate testarr2
+let testarr3 = testarr.concat testarr2
 
 let testarr4 = testarr2.reverse
 let _ =
@@ -147,5 +147,6 @@ let _ =
   assert((ca.forall (fn x => x>1))==False);
   assert((testarr4.get 0)==4);
   assert((testarr4.get 1)==3);
+  assert((testarr3.foldLeft (fn a x => a+x) 0)==12);
   ()
 

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -107,7 +107,6 @@ let primes n =
     arr)
 
 let ptab = primes 10
-
 let _ =
   assert (ptab.get 0 == 2);
   assert (ptab.get 1 == 3);

--- a/test/stdlib/stdlib0002_Mutable.fram
+++ b/test/stdlib/stdlib0002_Mutable.fram
@@ -107,6 +107,7 @@ let primes n =
     arr)
 
 let ptab = primes 10
+
 let _ =
   assert (ptab.get 0 == 2);
   assert (ptab.get 1 == 3);
@@ -119,3 +120,31 @@ let _ =
   assert (ptab.get 8 == 23);
   assert (ptab.get 9 == 29);
   ()
+
+let ca = [1,2,3,4].toConstArray
+
+let testarr = [1,2].toArray {~mut=ioMut}
+let testarr2 = [3,4].toArray {~mut=ioMut}
+let lst = ca.toList
+let lst2 = testarr.toList
+let process = testarr.map (fn x => x+1)
+let testarr3 = testarr.concatenate testarr2
+
+let testarr4 = testarr2.reverse
+let _ =
+  assert(lst.hdErr {~onError=(fn ()=> 2)} == 1);
+  assert(lst2.hdErr {~onError=(fn ()=> 2)} == 1);
+  assert((testarr.get 0)==2);
+  assert((testarr3.get 2)==3);
+  assert((testarr2.foldLeft (fn a x => a-x) 0)==(-7));
+  assert((testarr2.foldRight(fn x a => a-x) 0)==(-7));
+  assert((testarr.exists (fn x => x==2))==True);
+  assert((testarr.forall (fn x => x==2))==False);
+  assert((testarr.forall (fn x => x>0))==True);
+  assert((ca.exists (fn x => x>3 ))==True);
+  assert((ca.forall (fn x => x<5))==True);
+  assert((ca.exists (fn x => x<0))==False);
+  assert((ca.forall (fn x => x>1))==False);
+  assert((testarr4.get 0)==4);
+  ()
+


### PR DESCRIPTION
Revival of #182 with suggestions applied and added tests.

Changes:

- There are now forall methods to go with exists.
- Methods that unnecessarily used unsafeMakeArray instade of unsafeInitArray were rewritten.
- There are now tests.
- The old map is now called mapInPlace. 
- There now are not-in-place map methods for both mutable and immutable arrays.