### PR TITLE
Relaxed ANF for Core and Untyped

### DIFF
--- a/src/Eval/Eval.ml
+++ b/src/Eval/Eval.ml
@@ -40,6 +40,12 @@ let rec grab l comp cont gstack stack =
 let shift0 l comp cont stack =
   grab l comp cont [] stack
 
+let eval_lit (l : Lang.Untyped.lit) =
+  match l with
+  | LNum   n -> VNum n
+  | LNum64 n -> VNum64 n
+  | LStr   s -> VStr s
+
 let rec eval_expr env (e : Lang.Untyped.expr) cont =
   match e with
   | EValue v -> cont (eval_value env v)
@@ -54,11 +60,14 @@ let rec eval_expr env (e : Lang.Untyped.expr) cont =
           (env, (box, e)))
         env rds in
     eval_rec_defs env rds (fun env -> eval_expr env e2 cont)
-  | EApp(v1, v2) ->
-    begin match eval_value env v1 with
+  | EFn(x, body) ->
+    cont (VFn(fun v -> eval_expr (Env.extend env x v) body))
+  | EApp(e1, v2) ->
+    eval_expr env e1 (function
     | VFn f -> f (eval_value env v2) cont
-    | _ -> failwith "Runtime error!"
-    end
+    | _ -> failwith "Runtime error!")
+  | ECtor(n, vs) ->
+    cont (VCtor(n, List.map (eval_value env) vs))
   | EMatch(v, cls) ->
     begin match eval_value env v with
     | VCtor(n, vs) ->
@@ -107,14 +116,8 @@ and eval_rec_defs env rds cont =
 
 and eval_value env (v : Lang.Untyped.value) =
   match v with
-  | VNum n -> VNum n
-  | VNum64 n -> VNum64 n
-  | VStr s -> VStr s
+  | VLit l -> eval_lit l
   | VVar x -> Env.lookup env x
-  | VFn(x, body) ->
-    VFn(fun v -> eval_expr (Env.extend env x v) body)
-  | VCtor(n, vs) ->
-    VCtor(n, List.map (eval_value env) vs)
   | VExtern name ->
     begin match Hashtbl.find_opt External.extern_map name with
     | Some v -> v

--- a/src/Lang/Core.mli
+++ b/src/Lang/Core.mli
@@ -46,6 +46,25 @@ module TVar : sig
   module Map : Map1.S with type 'k key = 'k t
 end
 
+(** The flag indicating positivity of the recursion *)
+type rflag =
+  | Positive
+    (** The type is positively recursive. Unfolding it does not perform
+      non-termination effect. *)
+
+  | General
+    (** No assumptions about the positivity of the recursion. Unfolding
+      introduces non-termination effect. *)
+
+(** The flag indicating relevance of the value. *)
+type relevance =
+  | Relevant
+    (** The value is relevant, i.e., it is a regular value. *)
+
+  | Irrelevant
+    (** The value is computationally irrelevant. The computation cannot make
+      any decision based on it. *)
+
 (** Types, indexed by a type-represented kind *)
 type _ typ =
   | TEffPure : keffect typ
@@ -80,11 +99,15 @@ type _ typ =
       delim_tp  : ttype;
         (** Type of the delimiter *)
 
-      delim_eff : effct
+      delim_eff : effct;
         (** Effect of the delimiter *)
+
+      rflag : rflag
+        (** A flag indicating if the effect is positively recursive, and
+          therefore can be handled without performing NTerm effect. *)
     } -> ktype typ
 
-  | TData    : ttype * effct * ctor_type list -> ktype typ
+  | TData    : ttype * rflag * ctor_type list -> ktype typ
     (** Proof of the shape of ADT.
       
       Algebraic data type (ADTs) are just abstract types, but each operation
@@ -93,10 +116,10 @@ type _ typ =
       of ADTs. This approach simplifies many things, e.g., mutually recursive
       types are not recursive at all!
 
-      The element of type [TData(tp, eff, ctors)] is a witness that type [tp]
-      has constructors [ctors]. The effect [eff] is an effect of
-      pattern-matching: its pure for positively recursive types,
-      and impure for other types (because it may lead to non-termination). *)
+      The element of type [TData(tp, r, ctors)] is a witness that type [tp]
+      has constructors [ctors]. When the positivity flag [r] is set to
+      [Positive], the patter-matching is pure. Otherwise it introduces [NTerm]
+      effect. *)
 
   | TApp     : ('k1 -> 'k2) typ * 'k1 typ -> 'k2 typ
     (** Type application *)
@@ -141,7 +164,7 @@ type data_def =
       ctors : ctor_type list;
         (** List of constructors. *)
 
-      positive : bool
+      rflag : rflag
         (** A flag indicating if the type is positively recursive (in
           particular, not recursive at all) and therefore can be deconstructed
           without performing NTerm effect. *)
@@ -163,8 +186,12 @@ type data_def =
       delim_tp  : ttype;
         (** Type of the delimiter *)
 
-      delim_eff : effct
+      delim_eff : effct;
         (** Effect of the delimiter *)
+
+      rflag : rflag
+        (** A flag indicating if the effect is positively recursive, and
+          therefore can be handled without performing NTerm effect. *)
     }
 
 (* ========================================================================= *)
@@ -222,19 +249,35 @@ end
 
 (* ========================================================================= *)
 
-(** Expressions *)
+(** Literals *)
+type lit =
+  | LNum of int
+    (** Integer literal *)
+
+  | LNum64 of int64
+    (** 64 bit integer literal *)
+
+  | LStr of string
+    (** String literal *)
+
+(** Expressions.
+
+  Expressions are presented in slightly relaxed A-normal form. The main
+  difference is that any expression can be used as the left-hand side of
+  a function application, provided that it is pure. This approach still has
+  most of the benefits of A-normal form, but it able to keep track of
+  application to mutiple arguments. Moreover, irrelevant subexpressions
+  doesn't need to be values. **)
 type expr =
   | EValue of value
     (** value *)
 
   | ELet of var * expr * expr
-    (** Let expression *)
+    (** Let expression. Both subexpressions might be impure. *)
 
-  | ELetPure of var * expr * expr
-    (** Let expression, that binds pure expression *)
-
-  | ELetIrr of var * expr * expr
-    (** Let expression, that binds computationally irrelevant expression *)
+  | ELetPure of relevance * var * expr * expr
+    (** Let expression, that binds pure expression. The variable might be
+      marked as relevant or irrelevant. *)
 
   | ELetRec of (var * ttype * expr) list * expr
     (** Mutually recursive let-definitions. Recursive expressions must be
@@ -246,17 +289,35 @@ type expr =
       point, all recursive calls are allowed. It is used to ensure that
       recursive definitions are productive. *)
 
-  | EApp of value * value
-    (** Function application *)
+  | EFn  of var * ttype * expr
+    (** Lambda-abstraction *)
 
-  | ETApp : value * 'k typ -> expr
-    (** Type application *)
+  | ETFun : 'k tvar * expr -> expr
+    (** Type function *)
 
-  | ECApp of value
-    (** Instantiation of a constraint abstraction *)
+  | ECAbs of constr list * expr
+    (** Constraint abstraction *)
+
+  | EApp of expr * value
+    (** Function application. The subexpression must be pure. *)
+
+  | ETApp : expr * 'k typ -> expr
+    (** Type application. Always pure. *)
+
+  | ECApp of expr
+    (** Instantiation of a constraint abstraction. Always pure. *)
 
   | EData of data_def list * expr
     (** Mutually recursive datatype definitions *)
+
+  | ECtor of expr * int * Type.ex list * value list
+    (** Fully-applied constructor of an ADT. The meaning of the parameters
+      is the following.
+      - Computationally irrelevant proof that given that the type of the
+        whole expression is an ADT.
+      - An index of the constructor.
+      - Existential type parameters of the constructor.
+      - Regular parameters of the constructor. *)
 
   | EMatch  of expr * value * match_clause list * ttype * effct
     (** Shallow pattern matching. The first parameter is the proof that the
@@ -281,37 +342,19 @@ type expr =
     (** Print type (second parameter), evaluate and print the first expression,
       then continue to the second expression. *)
 
-(** Values *)
+(** Values.
+
+  Values are basic expressions, that are always pure, and can be duplicated at
+  minimal cost. Note that the notion of value does not correspond to values in
+  the reduction semantics. For instance, lambda-abstraction is not a value.
+  However, one could say that it is not a value, because the closure needs to be
+  allocated. *)
 and value =
-  | VNum of int
-    (** Integer literal *)
-
-  | VNum64 of int64
-    (** 64 bit integer literal *)
-
-  | VStr of string
-    (** String literal *)
+  | VLit of lit
+    (** Literal *)
 
   | VVar of var
     (** Variable *)
-
-  | VFn  of var * ttype * expr
-    (** Lambda-abstraction *)
-
-  | VTFun : 'k tvar * expr -> value
-    (** Type function *)
-
-  | VCAbs of constr list * expr
-    (** Constraint abstraction *)
-
-  | VCtor of expr * int * Type.ex list * value list
-    (** Fully-applied constructor of an ADT. The meaning of the parameters
-      is the following.
-      - Computationally irrelevant proof that given that the type of the
-        whole expression is an ADT.
-      - An index of the constructor.
-      - Existential type parameters of the constructor.
-      - Regular parameters of the constructor. *)
 
   | VExtern of string * ttype
     (** Externally defined function *)

--- a/src/Lang/CorePriv/Effect.ml
+++ b/src/Lang/CorePriv/Effect.ml
@@ -41,3 +41,15 @@ let rec is_pure eff =
 
   | TApp _ ->
     failwith "Internal error: TApp in effect"
+
+(** Translate rflag to effect *)
+let of_rflag rflag =
+  match rflag with
+  | Positive -> TEffPure
+  | General  -> nterm
+
+(** Join with [nterm], if the rflag is [General] *)
+let join_rflag rflag eff =
+  match rflag with
+  | Positive -> eff
+  | General  -> join nterm eff

--- a/src/Lang/CorePriv/SExprPrinter.ml
+++ b/src/Lang/CorePriv/SExprPrinter.ml
@@ -21,6 +21,11 @@ and tr_arrow_kind : type k. k kind -> SExpr.t list =
     tr_kind k1 :: tr_arrow_kind k2
   | KType | KEffect -> [ Sym "->"; tr_kind k ]
 
+let tr_rflag rflag =
+  match rflag with
+  | Positive -> Sym "+"
+  | General  -> Sym "o"
+
 let tr_var  x = Sym (Var.unique_name x)
 
 let tr_tvar (x : _ tvar) =
@@ -54,9 +59,10 @@ let rec tr_type : type k. k typ -> SExpr.t =
         List (List.map tr_tvar_binder_ex lbl.tvars);
         List (List.map tr_type lbl.val_types);
         tr_type lbl.delim_tp;
-        tr_type lbl.delim_eff ]
-  | TData(tp, eff, ctors) ->
-    List (Sym "data" :: tr_type tp :: List (tr_effect eff) ::
+        tr_type lbl.delim_eff;
+        tr_rflag lbl.rflag ]
+  | TData(tp, rflag, ctors) ->
+    List (Sym "data" :: tr_type tp :: tr_rflag rflag ::
       List.map tr_ctor_type ctors)
   | TApp _ -> tr_type_app tp []
 
@@ -129,18 +135,25 @@ let tr_data_def (dd : Syntax.data_def) =
       tr_type lbl.delim_eff
     ]
 
+let tr_lit (l : Syntax.lit) =
+  match l with
+  | LNum   n -> string_of_int n
+  | LNum64 n -> Int64.to_string n ^ "L"
+  | LStr   s -> Printf.sprintf "\"%s\"" (String.escaped s)
+
 let rec tr_expr (e : Syntax.expr) =
   match e with
   | EValue v -> tr_value v
-  | ELet _ | ELetPure _ | ELetIrr _ | ELetRec _ | ERecCtx _ | EData _
-  | EReset _ ->
+  | ELet _ | ELetPure _ | ELetRec _ | ERecCtx _ | EData _ | EReset _ ->
     List (Sym "defs" :: tr_defs e)
-  | EApp(v1, v2) ->
-    List [ Sym "app"; tr_value v1; tr_value v2 ]
-  | ETApp(v, tp) ->
-    List [ Sym "tapp"; tr_value v; tr_type tp ]
-  | ECApp v ->
-    List [ Sym "capp"; tr_value v ]
+  | EFn _ | ETFun _ | ECAbs _ ->
+    List (Sym "fn" :: tr_funs e)
+  | EApp _ | ETApp _ | ECApp _ ->
+    List (Sym "app" :: tr_apps e [])
+  | ECtor(proof, n, tps, args) ->
+    List (Sym "ctor" :: tr_expr proof :: Num n ::
+      (List (List.map (fun (Type.Ex tp) -> tr_type tp) tps)) ::
+      List.map tr_value args)
   | EMatch(proof, v, cls, tp, eff) ->
     List [ Sym "match"; tr_expr proof; tr_value v;
       List (Sym "clauses" :: List.map tr_clause cls);
@@ -161,20 +174,8 @@ let rec tr_expr (e : Syntax.expr) =
 
 and tr_value (v : Syntax.value) =
   match v with
-  | VNum n -> List [ Sym (string_of_int n) ]
-  | VNum64 n -> List [ Sym (Int64.to_string n ^ "L") ]
-  | VStr s -> List [ Sym (Printf.sprintf "\"%s\"" (String.escaped s)) ]
+  | VLit l -> List [ Sym (tr_lit l) ]
   | VVar x -> tr_var x
-  | VFn(x, tp, body) ->
-    List (Sym "fn" :: List [ tr_var x; tr_type tp ] :: tr_defs body)
-  | VTFun(x, body) ->
-    List (Sym "tfun" :: tr_tvar_binder x :: tr_defs body)
-  | VCAbs(cs, body) ->
-    List (Sym "cabs" :: List (List.map tr_constr cs) :: tr_defs body)
-  | VCtor(proof, n, tps, args) ->
-    List (Sym "ctor" :: tr_expr proof :: Num n ::
-      (List (List.map (fun (Type.Ex tp) -> tr_type tp) tps)) ::
-      List.map tr_value args)
   | VExtern(name, tp) ->
     List [ Sym "extern"; Sym name; tr_type tp ]
 
@@ -182,9 +183,9 @@ and tr_defs (e : Syntax.expr) =
   match e with
   | ELet(x, e1, e2) ->
     List [Sym "let"; tr_var x; tr_expr e1] :: tr_defs e2
-  | ELetPure(x, e1, e2) ->
+  | ELetPure(Relevant, x, e1, e2) ->
     List [Sym "let-pure"; tr_var x; tr_expr e1] :: tr_defs e2
-  | ELetIrr(x, e1, e2) ->
+  | ELetPure(Irrelevant, x, e1, e2) ->
     List [Sym "let-irr"; tr_var x; tr_expr e1] :: tr_defs e2
   | ELetRec(rds, e2) ->
     List (Sym "let-rec" :: List.map tr_rec_def rds) :: tr_defs e2
@@ -201,12 +202,37 @@ and tr_defs (e : Syntax.expr) =
         tr_var x; tr_expr ret
       ] :: tr_defs body
 
-  | EValue _ | EApp _ | ETApp _ | ECApp _ | EMatch _ | EShift _ | ERepl _
-  | EReplExpr _ ->
+  | EValue _ | EFn _ | ETFun _ | ECAbs _ | EApp _ | ETApp _ | ECApp _
+  | ECtor _ | EMatch _ | EShift _ | ERepl _ | EReplExpr _ ->
     [ tr_expr e ]
 
 and tr_rec_def (x, tp, body) =
   List [ tr_var x; tr_type tp; tr_expr body ]
+
+and tr_funs (e : Syntax.expr) =
+  match e with
+  | EFn(x, tp, body) ->
+    List [ tr_var x; tr_type tp ] :: tr_funs body
+  | ETFun(x, body) ->
+    List [Sym "type"; tr_tvar_binder x] :: tr_defs body
+  | ECAbs(cs, body) ->
+    List (Sym "constr" :: List.map tr_constr cs) :: tr_funs body
+
+  | EValue _ | ELet _ | ELetPure _ | ELetRec _ | ERecCtx _ | EApp _ | ETApp _
+  | ECApp _ | EData _ | ECtor _ | EMatch _ | EShift _ | EReset _ | ERepl _
+  | EReplExpr _ ->
+    [tr_expr e]
+
+and tr_apps (e : Syntax.expr) args =
+  match e with
+  | EApp(e1, v2) -> tr_apps e1 (tr_value v2 :: args)
+  | ETApp(e1, tp) -> tr_apps e1 (List [Sym "type"; tr_type tp] :: args)
+  | ECApp e1 -> tr_apps e1 (Sym "constr" :: args)
+
+  | EValue _ | ELet _ | ELetPure _ | ELetRec _ | ERecCtx _ | EFn _ | ETFun _
+  | ECAbs _ | EData _ | ECtor _ | EMatch _ | EShift _ | EReset _ | ERepl _
+  | EReplExpr _ ->
+    tr_expr e :: args
 
 and tr_clause (c : Syntax.match_clause) =
   List (

--- a/src/Lang/CorePriv/Subst.ml
+++ b/src/Lang/CorePriv/Subst.ml
@@ -55,11 +55,11 @@ let rec in_type_rec : type k. t -> k typ -> k typ =
       { effct; tvars;
         val_types = List.map (in_type_rec sub) lbl.val_types;
         delim_tp  = in_type_rec sub lbl.delim_tp;
-        delim_eff = in_type_rec sub lbl.delim_eff
+        delim_eff = in_type_rec sub lbl.delim_eff;
+        rflag     = lbl.rflag
       }
-  | TData(tp, eff, ctors) ->
-    TData(in_type_rec sub tp, in_type_rec sub eff,
-      List.map (in_ctor_type_rec sub) ctors)
+  | TData(tp, rflag, ctors) ->
+    TData(in_type_rec sub tp, rflag, List.map (in_ctor_type_rec sub) ctors)
   | TApp(tp1, tp2) ->
     TApp(in_type_rec sub tp1, in_type_rec sub tp2)
 

--- a/src/Lang/CorePriv/Syntax.ml
+++ b/src/Lang/CorePriv/Syntax.ml
@@ -10,11 +10,11 @@ type var = Var.t
 
 type data_def =
   | DD_Data of
-    { tvar      : TVar.ex;
-      proof     : var;
-      args      : TVar.ex list;
-      ctors     : ctor_type list;
-      positive  : bool
+    { tvar  : TVar.ex;
+      proof : var;
+      args  : TVar.ex list;
+      ctors : ctor_type list;
+      rflag : rflag
     }
   | DD_Label of
     { tvar      : keffect tvar;
@@ -22,20 +22,29 @@ type data_def =
       tvars     : TVar.ex list;
       val_types : ttype list;
       delim_tp  : ttype;
-      delim_eff : effct
+      delim_eff : effct;
+      rflag     : rflag
     }
+
+type lit =
+  | LNum   of int
+  | LNum64 of int64
+  | LStr   of string
 
 type expr =
   | EValue    of value
   | ELet      of var * expr * expr
-  | ELetPure  of var * expr * expr
-  | ELetIrr   of var * expr * expr
+  | ELetPure  of relevance * var * expr * expr
   | ELetRec   of (var * ttype * expr) list * expr
   | ERecCtx   of expr
-  | EApp      of value * value
-  | ETApp      : value * 'k typ -> expr
-  | ECApp     of value
+  | EFn       of var * ttype * expr
+  | ETFun      : 'k tvar * expr -> expr
+  | ECAbs     of constr list * expr
+  | EApp      of expr * value
+  | ETApp      : expr * 'k typ -> expr
+  | ECApp     of expr
   | EData     of data_def list * expr
+  | ECtor     of expr * int * Type.ex list * value list
   | EMatch    of expr * value * match_clause list * ttype * effct
   | EShift    of value * TVar.ex list * var list * var * expr * ttype
   | EReset    of value * Type.ex list * value list * expr * var * expr
@@ -43,14 +52,8 @@ type expr =
   | EReplExpr of expr * string * expr
 
 and value =
-  | VNum    of int
-  | VNum64  of int64
-  | VStr    of string
+  | VLit    of lit
   | VVar    of var
-  | VFn     of var * ttype * expr
-  | VTFun    : 'k tvar * expr -> value
-  | VCAbs   of constr list * expr
-  | VCtor   of expr * int * Type.ex list * value list
   | VExtern of string * ttype
 
 and match_clause = {

--- a/src/Lang/CorePriv/TypeBase.ml
+++ b/src/Lang/CorePriv/TypeBase.ml
@@ -78,6 +78,9 @@ end = struct
 end
 type 'k tvar = 'k TVar.t
 
+type rflag     = Positive | General
+type relevance = Relevant | Irrelevant
+
 type _ typ =
   | TEffPure : keffect typ
   | TEffJoin : effct * effct -> keffect typ
@@ -90,9 +93,10 @@ type _ typ =
       tvars     : TVar.ex list;
       val_types : ttype list;
       delim_tp  : ttype;
-      delim_eff : effct
+      delim_eff : effct;
+      rflag     : rflag
     } -> ktype typ
-  | TData    : ttype * effct * ctor_type list -> ktype typ
+  | TData    : ttype * rflag * ctor_type list -> ktype typ
   | TApp     : ('k1 -> 'k2) typ * 'k1 typ -> 'k2 typ
 
 and ttype  = ktype typ

--- a/src/Lang/CorePriv/WellTypedInvariant.ml
+++ b/src/Lang/CorePriv/WellTypedInvariant.ml
@@ -40,6 +40,10 @@ module Env : sig
     irrelevant contexts. *)
   val add_irr_var : t -> var -> ttype -> t
 
+  (** Extend the enviornment with a variable of given relevance (relevent or
+    irrelevant). *)
+  val add_var_rel : t -> relevance -> var -> ttype -> t
+
   (** Extend the environment with a recursively defined variable. It will be
     available only after the call to [enter_rec_ctx]. *)
   val add_rec_var : t -> var -> ttype -> t
@@ -118,6 +122,11 @@ end = struct
       var_map = Var.Map.add x (Irrelevant, tp) env.var_map
     }
 
+  let add_var_rel env (relevance : relevance) x tp =
+    match relevance with
+    | Relevant   -> add_var env x tp
+    | Irrelevant -> add_irr_var env x tp
+
   let add_rec_var env x tp =
     { env with
       var_map = Var.Map.add x (Recursive env.rec_level, tp) env.var_map
@@ -194,10 +203,11 @@ let rec tr_type : type k. Env.t -> k typ -> k typ =
       { effct; tvars;
         val_types = List.map (tr_type env) lbl.val_types;
         delim_tp  = tr_type env lbl.delim_tp;
-        delim_eff = tr_type env lbl.delim_eff
+        delim_eff = tr_type env lbl.delim_eff;
+        rflag     = lbl.rflag
       }
-  | TData(tp, eff, ctors) ->
-    TData(tr_type env tp, tr_type env eff, List.map (tr_ctor_type env) ctors)
+  | TData(tp, rflag, ctors) ->
+    TData(tr_type env tp, rflag, List.map (tr_ctor_type env) ctors)
   | TApp(tp1, tp2) ->
     TApp(tr_type env tp1, tr_type env tp2)
 
@@ -273,16 +283,25 @@ let rec check_data : type k.
 
 (** The first phase of checking recursive datatype: the type variable of the
   type definition is refreshed and added to the environment. The body of the
-  definition remains unchanged. *)
-let prepare_data_def env (dd : data_def) =
+  definition remains unchanged. If the type is marked as generally recursive,
+  it is added to non-recursive scope --- it may appear at non-positive
+  positions in positively recursive types. *)
+let prepare_data_def (env, nonrec_scope) (dd : data_def) =
+  let new_nonrec_scope a rflag =
+    match rflag with
+    | Positive -> nonrec_scope
+    | General  -> TVar.Set.add a nonrec_scope
+  in
   match dd with
   | DD_Data adt ->
     let (TVar.Ex a) = adt.tvar in
     let (env, a) = Env.add_tvar env a in
-    (env, DD_Data { adt with tvar = TVar.Ex a })
+    ((env, new_nonrec_scope a adt.rflag),
+      DD_Data { adt with tvar = TVar.Ex a })
   | DD_Label lbl ->
     let (env, a) = Env.add_tvar env lbl.tvar in
-    (env, DD_Label { lbl with tvar = a })
+    ((env, new_nonrec_scope a lbl.rflag),
+      DD_Label { lbl with tvar = a })
 
 (** Compute the effect attached to the datatype (the effect of
   pattern-matching). Types flagged as positive have pure effect
@@ -321,10 +340,9 @@ let finalize_data_def ~nonrec_scope (env, dd_eff) dd =
   | DD_Data adt ->
     let (TVar.Ex a) = adt.tvar in
     let (xs, data_tp, ctors) = check_data env (TVar a) adt.args adt.ctors in
-    let eff = adt_effect ~nonrec_scope adt.positive xs ctors in
     let env =
       Env.add_irr_var env adt.proof
-        (Type.t_foralls xs (TData(data_tp, eff, ctors))) in
+        (Type.t_foralls xs (TData(data_tp, adt.rflag, ctors))) in
     (env, dd_eff)
 
   | DD_Label lbl ->
@@ -333,7 +351,8 @@ let finalize_data_def ~nonrec_scope (env, dd_eff) dd =
     let val_types = List.map (tr_type eff_env) lbl.val_types in
     let delim_tp  = tr_type eff_env lbl.delim_tp in
     let delim_eff = tr_type eff_env lbl.delim_eff in
-    let lbl_tp = TLabel { effct; tvars; val_types; delim_tp; delim_eff } in
+    let lbl_tp = TLabel
+      { effct; tvars; val_types; delim_tp; delim_eff; rflag = lbl.rflag } in
     let env = Env.add_var env lbl.var lbl_tp in
     (* We add nterm effect since generation of a fresh label is not pure *)
     (env, Effect.join Effect.nterm dd_eff)
@@ -344,8 +363,16 @@ let finalize_data_def ~nonrec_scope (env, dd_eff) dd =
   definition in the block, otherwise the block is pure. *)
 let check_data_defs env dds =
   let nonrec_scope = Env.scope env in
-  let (env, dds) = List.fold_left_map prepare_data_def env dds in
+  let ((env, nonrec_scope), dds) =
+    List.fold_left_map prepare_data_def (env, nonrec_scope) dds in
   List.fold_left (finalize_data_def ~nonrec_scope) (env, TEffPure) dds
+
+(** Infer type of a literal *)
+let infer_lit_type l =
+  match l with
+  | LNum   _ -> TVar BuiltinType.tv_int
+  | LNum64 _ -> TVar BuiltinType.tv_int64
+  | LStr   _ -> TVar BuiltinType.tv_string
 
 (** Infer type end effect of given expression. *)
 let rec infer_type_eff env e =
@@ -355,28 +382,37 @@ let rec infer_type_eff env e =
     let (tp1, eff1) = infer_type_eff env e1 in
     let (tp2, eff2) = infer_type_eff (Env.add_var env x tp1) e2 in
     (tp2, Effect.join eff1 eff2)
-  | ELetPure(x, e1, e2) ->
-    let tp1 = infer_type_check_eff env e1 TEffPure in
-    infer_type_eff (Env.add_var env x tp1) e2
-  | ELetIrr(x, e1, e2) ->
-    let tp1 = infer_type_check_eff (Env.irrelevant env) e1 TEffPure in
-    infer_type_eff (Env.add_irr_var env x tp1) e2
+  | ELetPure(relevance, x, e1, e2) ->
+    let tp1 = infer_type_pure env e1 in
+    infer_type_eff (Env.add_var_rel env relevance x tp1) e2
   | ELetRec(rds, e) ->
     let env = check_rec_defs env rds in
     infer_type_eff env e
   | ERecCtx e ->
     let (tp, eff) = infer_type_eff (Env.enter_rec_ctx env) e in
     (tp, Effect.join eff Effect.nterm)
-  | EApp(v1, v2) ->
-    begin match infer_vtype env v1 with
+  | EFn(x, tp, body) ->
+    let tp = tr_type env tp in
+    let env = Env.add_var env x tp in
+    let (tp2, eff) = infer_type_eff env body in
+    (TArrow(tp, tp2, eff), TEffPure)
+  | ETFun(x, body) ->
+    let (env, x) = Env.add_tvar env x in
+    (TForall(x, infer_type_pure env body), TEffPure)
+  | ECAbs(cs, body) ->
+    let cs = List.map (tr_constr env) cs in
+    let env = Env.add_constrs env cs in
+    (TGuard(cs, infer_type_pure env body), TEffPure)
+  | EApp(e1, v2) ->
+    begin match infer_type_pure env e1 with
     | TArrow(tp2, tp1, eff) ->
       check_vtype env v2 tp2;
       (tp1, eff)
     | TVar _ | TForall _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
-  | ETApp(v, tp) ->
-    begin match infer_vtype env v with
+  | ETApp(e, tp) ->
+    begin match infer_type_pure env e with
     | TForall(x, body) ->
       let tp = tr_type env tp in
       begin match Kind.equal (TVar.kind x) (Type.kind tp) with
@@ -386,8 +422,8 @@ let rec infer_type_eff env e =
     | TVar _ | TArrow _ | TGuard _ | TLabel _ | TData _ | TApp _ ->
       failwith "Internal type error"
     end
-  | ECApp v ->
-    begin match infer_vtype env v with
+  | ECApp e ->
+    begin match infer_type_pure env e with
     | TGuard(cs, tp) ->
       if
         List.for_all
@@ -413,11 +449,14 @@ let rec infer_type_eff env e =
       failwith "Internal type error: escaping type variable"
     end
 
+  | ECtor(proof, n, tps, args) ->
+    (infer_ctor_type env proof n tps args (check_vtype env), TEffPure)
+
   | EMatch(proof, v, cls, tp, eff) ->
     let tp  = tr_type env tp in
     let eff = tr_type env eff in
-    begin match infer_type_check_eff (Env.irrelevant env) proof TEffPure with
-    | TData(data_tp, meff, ctors) when List.length cls = List.length ctors ->
+    begin match infer_type_pure (Env.irrelevant env) proof with
+    | TData(data_tp, rflag, ctors) when List.length cls = List.length ctors ->
       check_vtype env v data_tp;
       List.iter2 (fun cl ctor ->
           let xs  = cl.cl_vars in
@@ -428,7 +467,7 @@ let rec infer_type_eff env e =
           let env = List.fold_left2 Env.add_var env xs tps in
           check_type_eff env cl.cl_body tp eff
         ) cls ctors;
-      (tp, Effect.join meff eff)
+      (tp, Effect.join_rflag rflag eff)
     | _ ->
       failwith "Internal type error"
     end
@@ -483,24 +522,8 @@ let rec infer_type_eff env e =
 (** Infer type of given value *)
 and infer_vtype env v =
   match v with
-  | VNum _ -> TVar BuiltinType.tv_int
-  | VNum64 _ -> TVar BuiltinType.tv_int64
-  | VStr _ -> TVar BuiltinType.tv_string
+  | VLit l -> infer_lit_type l
   | VVar x -> Env.lookup_var env x
-  | VFn(x, tp, body) ->
-    let tp = tr_type env tp in
-    let env = Env.add_var env x tp in
-    let (tp2, eff) = infer_type_eff env body in
-    TArrow(tp, tp2, eff)
-  | VTFun(x, body) ->
-    let (env, x) = Env.add_tvar env x in
-    TForall(x, infer_type_check_eff env body TEffPure)
-  | VCAbs(cs, body) ->
-    let cs = List.map (tr_constr env) cs in
-    let env = Env.add_constrs env cs in
-    TGuard(cs, infer_type_check_eff env body TEffPure)
-  | VCtor(proof, n, tps, args) ->
-    infer_ctor_type env proof n tps args (check_vtype env)
   | VExtern(_, tp) -> tr_type env tp
 
 (** [infer_ctor_type env proof n tps args check_arg] checks the type of [n]-th
@@ -510,7 +533,7 @@ and infer_vtype env v =
   type. *)
 and infer_ctor_type env proof n tps args check_arg =
   assert (n >= 0);
-  begin match infer_type_check_eff (Env.irrelevant env) proof TEffPure with
+  begin match infer_type_pure (Env.irrelevant env) proof with
   | TData(tp, _, ctors) ->
     begin match List.nth_opt ctors n with
     | Some ctor ->
@@ -526,6 +549,11 @@ and infer_ctor_type env proof n tps args check_arg =
   | _ ->
     failwith "Internal type error"
   end
+
+(** Infer type of given expression, while checking if it is pure. The
+  function returns the type of the expression. *)
+and infer_type_pure env e =
+  infer_type_check_eff env e TEffPure
 
 (** Infer type of the expression, but check its effect *)
 and infer_type_check_eff env e eff =

--- a/src/Lang/Untyped.ml
+++ b/src/Lang/Untyped.ml
@@ -2,10 +2,22 @@
  * See LICENSE for details.
  *)
 
-(** Untyped language. In A-normal form. *)
+(** Untyped language. Similarly to Core, it is in a slightly relaxed A-normal
+  form. *)
 
 (** Variables *)
 type var = Var.t
+
+(** Literals *)
+type lit =
+  | LNum of int
+    (** Integer literal *)
+
+  | LNum64 of int64
+    (** 64 bit integer literal *)
+
+  | LStr of string
+    (** String literal *)
 
 (** Expressions *)
 type expr =
@@ -18,8 +30,14 @@ type expr =
   | ELetRec of (var * expr) list * expr
     (** Mutually recursive let-definitions *)
 
-  | EApp of value * value
+  | EFn of var * expr
+    (** Function *)
+
+  | EApp of expr * value
     (** Function application *)
+
+  | ECtor of int * value list
+    (** Fully applied constructor of ADT *)
 
   | EMatch of value * clause list
     (** Pattern-matching *)
@@ -45,27 +63,16 @@ type expr =
     (** Print type (second parameter), evaluate and print the first expression,
       then continue to the second expression. *)
 
-(** Values *)
+(** Trivial values, with minimal cost of copying. *)
 and value =
-  | VNum of int
-    (** Integer literal *)
-
-  | VNum64 of int64
-    (** 64 bit integer literal *)
-
-  | VStr of string
-    (** String literal *)
+  | VLit of lit
+    (** Literal *)
 
   | VVar of var
     (** Variable *)
 
-  | VFn of var * expr
-    (** Function *)
-
-  | VCtor of int * value list
-    (** Fully applied constructor of ADT *)
-
   | VExtern of string
+    (** Externally defined value *)
 
 (** Pattern-matching clause *)
 and clause = var list * expr

--- a/src/ToCore/Common.ml
+++ b/src/ToCore/Common.ml
@@ -27,7 +27,7 @@ let v_unit_prf =
       T.ctor_tvars     = [];
       T.ctor_arg_types = []
     } in
-  T.VExtern("__Unit_Proof__", T.TData(T.Type.t_unit, T.TEffPure, [ ctor ]))
+  T.VExtern("__Unit_Proof__", T.TData(T.Type.t_unit, T.Positive, [ ctor ]))
 
 (** Proof that bool is an ADT *)
 let v_bool_prf =
@@ -43,7 +43,7 @@ let v_bool_prf =
     } in
   let data_tp = T.TData(
     T.Type.t_bool,
-    T.TEffPure,
+    T.Positive,
     [ ctor_false; ctor_true ]) in
   T.VExtern("__Bool_Proof__", data_tp)
 
@@ -62,6 +62,6 @@ let v_option_prf =
     } in
   let data_tp = T.TData(
     T.Type.t_option (T.TVar arg),
-    T.TEffPure,
+    T.Positive,
     [ ctor_none; ctor_some ]) in
   T.VExtern("__Option_Proof__", T.TForall(arg, data_tp))

--- a/src/ToCore/DataType.ml
+++ b/src/ToCore/DataType.ml
@@ -69,11 +69,11 @@ let finalize_data_def env (dd : data_def) =
     let (env, args) = Env.add_named_tvars env dd.args in
     let ctors = tr_ctor_decls env dd.ctors in
     T.DD_Data {
-      tvar      = dd.tvar;
-      proof     = dd.proof;
-      args      = args;
-      ctors     = ctors;
-      positive  = dd.positive;
+      tvar  = dd.tvar;
+      proof = dd.proof;
+      args  = args;
+      ctors = ctors;
+      rflag = if dd.positive then T.Positive else T.General
     }
 
   | DD_Label dd ->
@@ -83,7 +83,8 @@ let finalize_data_def env (dd : data_def) =
       tvars     = [];
       val_types = [];
       delim_tp  = Type.tr_ttype  env dd.delim_tp;
-      delim_eff = Type.tr_ceffect env (Impure dd.delim_eff)
+      delim_eff = Type.tr_ceffect env (Impure dd.delim_eff);
+      rflag     = T.General
     }
 
 let tr_data_defs env dds =

--- a/src/ToCore/Type.ml
+++ b/src/ToCore/Type.ml
@@ -44,7 +44,8 @@ let rec tr_type env tp =
           tvars     = [];
           val_types = [];
           delim_tp  = tr_ttype env delim_tp;
-          delim_eff = tr_ceffect env (Impure delim_eff)
+          delim_eff = tr_ceffect env (Impure delim_eff);
+          rflag     = T.General
         })
 
   | THandler h ->


### PR DESCRIPTION
This pull request changes the definition of Core and Untyped languages. The changes can be summarized as follows:

- Both languages are presented in a slightly relaxed A-normal form, that better fits to compiler: expression is considered a value if it can be copied at no cost, and LHS of an application is a (pure) expression in order to keep track of application of multiple arguments to functions.

- The requirements for checking positivity of recursive type definition is relaxed: generally recursive types and effects defined within the same block as the positive one can appear on any, not necessarily positive position.

- The separate type for literals is introduced in both languages.