### PR TITLE
Simplified type annotations in Prelude format methods

### DIFF
--- a/lib/Base/Format.fram
+++ b/lib/Base/Format.fram
@@ -8,9 +8,11 @@ import open /Base/Operators
 
 parameter X
 parameter XFmt
+parameter method format : {?fmt : XFmt, ?prec : Int} -> X ->> String
 
 parameter Y
 parameter YFmt
+parameter method format : {?fmt : YFmt, ?prec : Int} -> Y ->> String
 
 ## ## Unit
 
@@ -52,59 +54,41 @@ pub method format {?prec : Int, ?fmt : Unit} (self : String) =
 
 ## ## List
 
-pub method format 
-  { method format : {?prec : Int, ?fmt : XFmt} -> X ->> String
-  , ?prec : Int
-  , ?fmt : Unit } 
-  (self : List X) = 
-    let rec iter (xs : List X) =
-      match xs with
-      | [] => "]"
-      | [x] => x.format + "]"
-      | x :: xs => x.format + ", " + iter xs
-      end in
-    "[" + iter self
+pub method format {?prec : Int, ?fmt : Unit } (self : List X) = 
+  let rec iter (xs : List X) =
+    match xs with
+    | [] => "]"
+    | [x] => x.format + "]"
+    | x :: xs => x.format + ", " + iter xs
+    end in
+  "[" + iter self
 
 ## ## Option
 
-pub method format
-  { method format : {?prec : Int, ?fmt : XFmt} -> X ->> String
-  , ?prec : Int
-  , ?fmt : Unit }
-  (self : Option X) = 
-    match self with
-    | None => "None"
-    | Some x =>
-      if prec.unwrapOr 0 >= 200 then
-        "(Some " + x.format {prec=200} + ")"
-      else
-        "Some " + x.format {prec=200}
-    end
+pub method format {?prec : Int, ?fmt : Unit } (self : Option X) = 
+  match self with
+  | None => "None"
+  | Some x =>
+    if prec.unwrapOr 0 >= 200 then
+      "(Some " + x.format {prec=200} + ")"
+    else
+      "Some " + x.format {prec=200}
+  end
 
 ## ## Pair
 
-pub method format
-  { method format : {?prec : Int, ?fmt : XFmt} -> X ->> String
-  , method format : {?prec : Int, ?fmt : YFmt} -> Y ->> String
-  , ?prec : Int
-  , ?fmt : Unit }
-  ((x, y) : Pair X Y) =
-    "(" + x.format + ", " + y.format + ")"
+pub method format {?prec : Int, ?fmt : Unit } ((x, y) : Pair X Y) =
+  "(" + x.format + ", " + y.format + ")"
 
 ## ## Either
 
-pub method format
-  { method format : {?prec : Int, ?fmt : XFmt} -> X ->> String
-  , method format : {?prec : Int, ?fmt : YFmt} -> Y ->> String
-  , ?prec : Int
-  , ?fmt : Unit }
-  (self : Either X Y) =
-    let str =
-      match self with
-      | Left x  => "Left "  + x.format {prec=200}
-      | Right y => "Right " + y.format {prec=200}
-      end in
-    if prec.unwrapOr 0 >= 200 then
-      "(" + str + ")"
-    else
-      str
+pub method format {?prec : Int, ?fmt : Unit } (self : Either X Y) =
+  let str =
+    match self with
+    | Left x  => "Left "  + x.format {prec=200}
+    | Right y => "Right " + y.format {prec=200}
+    end in
+  if prec.unwrapOr 0 >= 200 then
+    "(" + str + ")"
+  else
+    str


### PR DESCRIPTION
Thanks to recent fixes to parameters/method resolve, format method in Prelude can be simplified by using universally defined `parameter method format` for X and Y