### PR TITLE
Add: Expose maximum array length (#170)

### DIFF
--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -127,6 +127,9 @@ let unsafeSetArray {E, type T} =
 let unsafeMakeArray {E, type T} =
   extern dbl_mkArray : Int ->[E] Array E T
 
+{## Get the maximum length of an array. ##}
+pub let maxArrayLength = (extern dbl_maxArrayLength : Int)
+
 {## Get the length of an array. ##}
 pub method length {E} =
   extern dbl_arrayLength : Array E _ -> Int

--- a/src/Eval/ExternalRef.ml
+++ b/src/Eval/ExternalRef.ml
@@ -23,6 +23,7 @@ let extern_ref_seq =
     "dbl_arrayGet",   array_fun (fun a -> int_fun (fun n -> a.(n)));
     "dbl_arraySet",   array_fun (fun a -> int_fun (fun n -> pure_fun (fun v ->
                         a.(n) <- v; v_unit)));
+    "dbl_maxArrayLength", VNum Sys.max_array_length;
     "dbl_arrayLength", array_fun (fun a -> VNum (Array.length a));
   ] |> List.to_seq
 


### PR DESCRIPTION
The developer can now write the following code:

```
$ dbl
> let maxLength = extern dbl_maxArrayLength : Int ;;
> maxLength ;;
: Int
= 18014398509481983
> 
```