### PR TITLE
Use `toString` method in interpolation

### DIFF
--- a/lib/Base/Bool.fram
+++ b/lib/Base/Bool.fram
@@ -4,7 +4,7 @@
 
 import open Types
 
-pub method toString self = if self then "True" else "False"
+pub method toString {?fmt : Unit} self = if self then "True" else "False"
 
 pub method neg self =
   if self then False else True

--- a/lib/Base/Char.fram
+++ b/lib/Base/Char.fram
@@ -17,3 +17,6 @@ pub method le    = (extern dbl_leInt  : Char -> Char -> Bool)
 
   Additional quotes are not added around the result. ##}
 pub method escape = (extern dbl_chrEscape : Char -> String)
+
+pub method toString {?fmt : Unit} (self : Char) =
+  (extern dbl_chrToString : Char -> String) self

--- a/lib/Base/Int.fram
+++ b/lib/Base/Int.fram
@@ -6,7 +6,7 @@ import open Types
 import open Operators
 import open Assert
 
-pub method toString = (extern dbl_intToString : Int -> String)
+pub method toString {?fmt : Unit} = (extern dbl_intToString : Int -> String)
 
 pub method toInt64  = (extern dbl_intToInt64 : Int -> Int64)
 

--- a/lib/Base/Int64.fram
+++ b/lib/Base/Int64.fram
@@ -35,7 +35,8 @@ pub method ashiftr = (extern dbl_asrInt64 : Int64 -> Int64 -> Int64)
 pub method succ (self : Int64) = self + 1L
 pub method pred (self : Int64) = self - 1L
 
-pub method toString = (extern dbl_int64ToString : Int64 -> String)
+pub method toString {?fmt : Unit} =
+  (extern dbl_int64ToString : Int64 -> String)
 
 pub method toIntErr { ~onError } (self : Int64) =
   if self <= Int.maxValue.toInt64 && self >= Int.minValue.toInt64 then

--- a/lib/Base/String.fram
+++ b/lib/Base/String.fram
@@ -34,3 +34,5 @@ pub method toList (self : String) =
 
   Additional quotes are not added around the string. ##}
 pub method escape = (extern dbl_strEscape : String -> String)
+
+pub method toString {?fmt : Unit} (self : String) = self

--- a/src/DblParser/Desugar.ml
+++ b/src/DblParser/Desugar.ml
@@ -531,8 +531,8 @@ and tr_expr (e : Raw.expr) =
   | EStr s -> make (EStr s)
   | EChr c -> make (EChr c)
   | EInterp (s, xs) ->
-    let tr_format (expr : Raw.expr) (fmt : Raw.expr option) = 
-      let mth = { pos = expr.pos; data = (Raw.EMethod (expr, "format"))} in
+    let tr_toString (expr : Raw.expr) (fmt : Raw.expr option) = 
+      let mth = { pos = expr.pos; data = (Raw.EMethod (expr, "toString"))} in
       match fmt with
       | Some fmt ->
         let make_fmt data = { fmt with data } in
@@ -545,7 +545,7 @@ and tr_expr (e : Raw.expr) =
     let tr_string str = with_nowhere (Raw.EStr str) in
     let rec flat_interp = function
       | (expr, fmt, str) :: xs 
-        -> tr_format expr fmt :: tr_string str :: flat_interp xs
+        -> tr_toString expr fmt :: tr_string str :: flat_interp xs
       | [] -> [] in
     let arg_list = make (Raw.EList (tr_string s :: flat_interp xs)) in
     let expr = make (Raw.EApp (make (Raw.EExtern "dbl_strListCat"), [arg_list]))

--- a/src/Eval/ExternalStr.ml
+++ b/src/Eval/ExternalStr.ml
@@ -33,7 +33,8 @@ let extern_str_seq =
     "dbl_strLen",  str_fun (fun s -> VNum (String.length s));
     "dbl_strGet", 
       str_fun (fun s -> int_fun (fun n -> VNum (Char.code s.[n])));
-    "dbl_chrEscape",  int_fun (fun c -> VStr (Char.escaped (Char.chr c)));
+    "dbl_chrToString", int_fun (fun c -> VStr (String.make 1 (Char.chr c)));
+    "dbl_chrEscape",   int_fun (fun c -> VStr (Char.escaped (Char.chr c)));
     "dbl_chrListToStr",
       list_fun to_char (fun xs -> VStr (List.to_seq xs |> String.of_seq));
     "dbl_chrCode",    int_fun (fun c -> VNum c);

--- a/test/ok/ok0136_stringInterpolation.fram
+++ b/test/ok/ok0136_stringInterpolation.fram
@@ -2,7 +2,7 @@ data rec List A = [] | (::) of A, List A
 
 data UnitFmt = UnitFmt of { ?unit : String }
 
-method format {?prec : Int, ?fmt : UnitFmt} () =
+method toString {?prec : Int, ?fmt : UnitFmt} () =
   match fmt with
   | Some (UnitFmt {unit=Some name}) => name
   | _ => "()"

--- a/test/stdlib/stdlib0005_ToString.fram
+++ b/test/stdlib/stdlib0005_ToString.fram
@@ -1,0 +1,28 @@
+# Bool
+let _ =
+  assert ((True).toString == "True");
+  assert ((False).toString == "False")
+
+# String
+let _ =
+  assert ("abc".toString == "abc");
+  assert ("".toString == "");
+  assert ("\n".toString == "\n")
+
+# Char
+let _ =
+  assert (' '.toString == " ");
+  assert ('a'.toString == "a");
+  assert ('\n'.toString == "\n")
+
+# Int
+let _ =
+  assert (10.toString == "10");
+  assert (0.toString == "0");
+  assert ((-1).toString == "-1")
+
+# Int64
+let _ =
+  assert (10L.toString == "10");
+  assert (0L.toString == "0");
+  assert ((-1L).toString == "-1")


### PR DESCRIPTION
This PR replaces `format` method with `toString` method in string interpolation. PR also introduces 5 toString methods for basic types.