### PR TITLE
Add a nested handler test

### DIFF
--- a/test/ok/ok0139_nestedHandlers.fram
+++ b/test/ok/ok0139_nestedHandlers.fram
@@ -1,0 +1,22 @@
+let printStrLn = extern dbl_printStrLn : String ->[IO] Unit
+let addInt = extern dbl_addInt : Int -> Int -> Int
+method toString = (extern dbl_intToString : Int -> String)
+
+data Reader E X = {
+   ask : Unit ->[E] X
+}
+
+let hReader init =
+  handler Reader
+    { ask = effect () / r => r init
+    }
+  end
+
+let (res : Int) = 
+  handle r1 with hReader 1 in
+  handle r2 with hReader 5 in
+  addInt (r1.ask ()) (r2.ask ())
+
+let _ = printStrLn res.toString
+# @stdout:6
+


### PR DESCRIPTION
During my work on parametric handlers I got to a point where the entire `dbl` test suite would pass, but `dbl` would crash on the Prolog example. Turns out we don't have any nested handlers in our test suite, so I added a simple one.