### PR TITLE
Consistent naming for outer scopes and environments

### DIFF
--- a/src/EffectInference/Common.ml
+++ b/src/EffectInference/Common.ml
@@ -21,7 +21,7 @@ type origin =
     (** Constraint generated during instantiation of a scheme. *)
 
   | ODataScope of Position.t * PPTree.t * T.typ * T.ceffect
-    (** Constraint generated during checking if data definitions doesn't
+    (** Constraint generated during checking if data definitions don't
       escape their scope. *)
 
   | OHandlerScope of Position.t * PPTree.t * T.tvar * T.typ

--- a/src/EffectInference/Constr.ml
+++ b/src/EffectInference/Constr.ml
@@ -12,12 +12,12 @@ type t =
 let to_sexpr (CSubeffect(_, eff1, eff2)) =
   SExpr.List [T.Effct.to_sexpr eff1; Sym "<:"; T.Effct.to_sexpr eff2]
 
-let collect_constr_gvars ~scope c gvs =
+let collect_constr_gvars ~outer_scope c gvs =
   match c with
   | CSubeffect(_, eff1, eff2) ->
     gvs
-    |> T.Effct.collect_gvars ~scope eff1
-    |> T.Effct.collect_gvars ~scope eff2
+    |> T.Effct.collect_gvars ~outer_scope eff1
+    |> T.Effct.collect_gvars ~outer_scope eff2
 
-let collect_gvars ~scope cs gvs =
-  List.fold_left (fun gvs c -> collect_constr_gvars ~scope c gvs) gvs cs
+let collect_gvars ~outer_scope cs gvs =
+  List.fold_left (fun gvs c -> collect_constr_gvars ~outer_scope c gvs) gvs cs

--- a/src/EffectInference/Constr.mli
+++ b/src/EffectInference/Constr.mli
@@ -12,8 +12,9 @@ type t =
     (** Subeffect constraint. *)
 
 (** Collect all generalizable variables that do not belong to the given
-  scope and add them to the given set. *)
-val collect_gvars : scope:Scope.t -> t list -> T.GVar.Set.t -> T.GVar.Set.t
+  (outer) scope and add them to the given set. *)
+val collect_gvars :
+  outer_scope:Scope.t -> t list -> T.GVar.Set.t -> T.GVar.Set.t
 
 (** Pretty-print constraint as S-expression *)
 val to_sexpr : t -> SExpr.t

--- a/src/EffectInference/ConstrSimplify.ml
+++ b/src/EffectInference/ConstrSimplify.ml
@@ -8,7 +8,7 @@ open Common
 
 (** Internal state of the simplification procedure. *)
 type state =
-  {         scope    : Scope.t;
+  {         outer_scope : Scope.t;
       (** The current outer scope. Generalizable variables that do not belong
         to this scope can be altered by the simplification process. *)
 
@@ -19,8 +19,8 @@ type state =
       (** Positive generalizable variables, or more precisely, generalizable
         variables that appear on non-negative positions of the generalized
         type. Simplification procedure cares about variables that do not
-        belong to [scope], so other variables may not be in this set, even
-        if they are positive. *)
+        belong to [outer_scope], so other variables may not be in this set,
+        even if they are positive. *)
 
     mutable ngvs     : T.GVar.Set.t;
       (** Negative generalizable variables, or more precisely, generalizable
@@ -40,8 +40,8 @@ type state =
 
     mutable irr      : Constr.t list
       (** Irrelevant constraints, i.e., that do not contain any generalizable
-        variable outside of [scope]. Such constraints are stored here to be
-        re-added at the end of the simplification process. *)
+        variable outside of [outer_scope]. Such constraints are stored here to
+        be re-added at the end of the simplification process. *)
   }
 
 (** Effect variable (regular or generalizable). Generalizable variables are
@@ -79,8 +79,8 @@ type constr =
 (* ========================================================================= *)
 (* Basic operations *)
 
-let initial_state ~scope ~pgvs ~ngvs =
-  { scope;
+let initial_state ~outer_scope ~pgvs ~ngvs =
+  { outer_scope;
     progress = false;
     pgvs;
     ngvs;
@@ -133,13 +133,13 @@ module EffVarMap = Map.Make(EffVar)
 let is_eff_irrelevant st eff =
   let (_, gvars) = T.Effct.view eff in
   List.for_all
-    (fun (gv, _) -> T.GVar.in_scope gv st.scope)
+    (fun (gv, _) -> T.GVar.in_scope gv st.outer_scope)
     gvars
 
 (** Check if generalizable variable [gv] is irrelevant, i.e., it belongs
   to the current outer scope. *)
 let is_gvar_irrelevant st gv =
-  T.GVar.in_scope gv st.scope
+  T.GVar.in_scope gv st.outer_scope
 
 (** Normalize a constraint of the form [x ? p <: eff2], where [x] is a type
   variable. *)
@@ -211,16 +211,16 @@ let to_constr (c : constr) =
 
 (** [set_gvar st gv eff] sets the variable [gv] to the effect [eff], and
   updates the positive/negative sets accordingly. It is assumed that [gv] is
-  not in the outer scope ([st.scope]) and that [eff] does not contain [gv]
-  itself. *)
+  not in the outer scope ([st.outer_scope]) and that [eff] does not contain
+  [gv] itself. *)
 let set_gvar st gv eff =
   assert (IncrSAT.Formula.is_false (T.Effct.lookup_gvar eff gv));
-  assert (not (T.GVar.in_scope gv st.scope));
+  assert (not (T.GVar.in_scope gv st.outer_scope));
   let (_, eff_gvs) = T.Effct.view eff in
   let eff_gvs =
     eff_gvs
     |> List.filter_map (fun (gv, _) ->
-        if T.GVar.in_scope gv st.scope then None else Some gv)
+        if T.GVar.in_scope gv st.outer_scope then None else Some gv)
     |> T.GVar.Set.of_list
   in
   if T.GVar.Set.mem gv st.pgvs then begin
@@ -234,22 +234,22 @@ let set_gvar st gv eff =
 
 (** Variables that appear on the left-hand-side of any constraint. *)
 let lhs_gvars st cs =
-  let scope = st.scope in
+  let outer_scope = st.outer_scope in
   List.fold_left
     (fun gvs (c : constr) ->
       match c.eff_var with
       | GVar eff_var ->
-        T.Effct.collect_gvars ~scope eff_var gvs
+        T.Effct.collect_gvars ~outer_scope eff_var gvs
       | TVar _ -> gvs)
     T.GVar.Set.empty
     cs
 
 (** Variables that appear on the right-hand-side of any constraint. *)
 let rhs_gvars st cs =
-  let scope = st.scope in
+  let outer_scope = st.outer_scope in
   List.fold_left
     (fun gvs (c : constr) ->
-      T.Effct.collect_gvars ~scope c.rhs_effect gvs)
+      T.Effct.collect_gvars ~outer_scope c.rhs_effect gvs)
     T.GVar.Set.empty
     cs
 
@@ -286,7 +286,7 @@ let build_single_upper_bounds st bnd (c : constr) =
   | TVar _   -> bnd (* Not a generalizable variable. *)
   | GVar eff ->
     let gv = get_gvar eff in
-    if T.GVar.in_scope gv st.scope then
+    if T.GVar.in_scope gv st.outer_scope then
       (* Variable is irrelevant (it is in the outer scope), ignore it. *)
       bnd
     else if T.GVar.Set.mem gv st.pgvs then
@@ -462,7 +462,7 @@ let rec simplify_loop st cs =
   else
     cs
 
-let simplify ~scope ~pgvs ~ngvs cs =
-  let st = initial_state ~scope ~pgvs ~ngvs in
+let simplify ~outer_scope ~pgvs ~ngvs cs =
+  let st = initial_state ~outer_scope ~pgvs ~ngvs in
   let cs = simplify_loop st cs in
   cs @ st.irr

--- a/src/EffectInference/ConstrSimplify.mli
+++ b/src/EffectInference/ConstrSimplify.mli
@@ -6,10 +6,11 @@
 
 open Common
 
-(** Simplify the set of constraints. The [scope] is an outer scope of the
-  place of the generalization. Variables in [pgvs] are those that appear on
-  non-negative positions, and therefore cannot be promoted to supereffects.
+(** Simplify the set of constraints. The [outer_scope] is an outer scope of
+  the place of the generalization. Variables in [pgvs] are those that appear
+  on non-negative positions, and therefore cannot be promoted to supereffects.
   Dually, [ngvs] appears on non-positive positions, so cannot be downgraded
   to subeffects. *)
-val simplify : scope:Scope.t -> pgvs:T.GVar.Set.t -> ngvs:T.GVar.Set.t ->
-  Constr.t list -> Constr.t list
+val simplify :
+  outer_scope:Scope.t -> pgvs:T.GVar.Set.t -> ngvs:T.GVar.Set.t ->
+    Constr.t list -> Constr.t list

--- a/src/EffectInference/ConstrSolver.mli
+++ b/src/EffectInference/ConstrSolver.mli
@@ -10,46 +10,52 @@ open Common
 val add_constraint : origin:origin -> Env.t -> T.effct -> T.effct -> unit
 
 (** Leave scope of [tvars] type variables. Use this function only in
-  type-checking mode. *)
-val leave_scope : env0:Env.t -> tvars:T.tvar list -> Constr.t list -> unit
+  type-checking mode. The [outer_env] is an outer environment. *)
+val leave_scope :
+  outer_env:Env.t -> tvars:T.tvar list -> Constr.t list -> unit
 
-(** Leave scope of [tvars] type variables, returning a type scheme. The [env0]
-  is an outer environment. *)
+(** Leave scope of [tvars] type variables, returning a type scheme. The
+  [outer_env] is an outer environment. *)
 val leave_scope_with_scheme :
-  env0:Env.t -> tvars:T.tvar list -> Constr.t list -> T.scheme -> unit
+  outer_env:Env.t -> tvars:T.tvar list -> Constr.t list -> T.scheme -> unit
 
-(** Same as [leave_scope_with_scheme], but take a list of type schemes. *)
+(** Same as [leave_scope_with_scheme], but take a list of type schemes. The
+  [outer_env] is an outer environment. *)
 val leave_scope_with_schemes :
-  env0:Env.t -> tvars:T.tvar list -> Constr.t list -> T.scheme list -> unit
+  outer_env:Env.t -> tvars:T.tvar list ->
+    Constr.t list -> T.scheme list -> unit
 
 (** Leave scope of [tvars] type variables, returning a type and effect. The
-  [env0] is an outer environment. *)
+  [outer_env] is an outer environment. *)
 val leave_scope_with_type_eff :
-  env0:Env.t -> tvars:T.tvar list -> Constr.t list -> T.typ -> T.ceffect ->
-    unit
+  outer_env:Env.t -> tvars:T.tvar list ->
+    Constr.t list -> T.typ -> T.ceffect -> unit
 
 (** Leave scope of [tvars] type variables, returning a list of constructors.
-  The [env0] is an outer environment. *)
+  The [outer_env] is an outer environment. *)
 val leave_scope_with_ctors :
-  env0:Env.t -> tvars:T.tvar list -> Constr.t list -> T.ctor_decl list ->
-    unit
+  outer_env:Env.t -> tvars:T.tvar list ->
+    Constr.t list -> T.ctor_decl list -> unit
 
 (** Leave scope of [tvars] type variables, returning an entity that may
-  contains given list of generalizable variable defined at the leaved scope.
-  The [env0] is an outer environment. *)
+  contains given list of generalizable variable defined at the leaved (inner)
+  scope. The [outer_env] is an outer environment. *)
 val leave_scope_with_gvars :
-  env0:Env.t -> tvars:T.tvar list -> Constr.t list -> T.GVar.Set.t -> unit
+  outer_env:Env.t -> tvars:T.tvar list ->
+    Constr.t list -> T.GVar.Set.t -> unit
 
 (** Leave scope and generalize generalizable variables. Returns generalized
   variables promoted to type variables, and the list of constraints that
   could not be propagated and should be generalized. There should be no
-  regular variables defined at the leaved scope. *)
+  regular variables defined at the leaved (inner) scope. The [outer_env] is an
+  outer environment. *)
 val generalize_with_scheme :
-  env0:Env.t -> Constr.t list -> T.scheme -> T.tvar list * T.constr list
+  outer_env:Env.t -> Constr.t list -> T.scheme -> T.tvar list * T.constr list
 
 (** Same as [generalize_with_scheme], but takes multiple type schemes. *)
 val generalize_with_schemes :
-  env0:Env.t -> Constr.t list -> T.scheme list -> T.tvar list * T.constr list
+  outer_env:Env.t ->
+    Constr.t list -> T.scheme list -> T.tvar list * T.constr list
 
 (** Solve all constraints collected in given environment. *)
 val final_solve : Env.t -> unit

--- a/src/EffectInference/Expr.ml
+++ b/src/EffectInference/Expr.ml
@@ -116,15 +116,15 @@ let rec tr_poly_expr env named (e : S.poly_expr) =
     ExprUtils.generalize [] named e sch
 
   | ECtor(targs, prf, idx) ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, targs) = Env.add_named_tvars env targs in
     let (env, named) = tr_named_params env named in
     let (prf, tp, ctors, _) = ProofExpr.tr_proof_expr env prf in
     let (e, sch) = ExprUtils.mk_ctor ~prf ~idx tp ctors in
     let (e, sch) = ExprUtils.generalize targs named e sch in
-    ConstrSolver.leave_scope_with_scheme ~env0 ~tvars:(List.map snd targs)
-      (Env.constraints env) sch;
+    ConstrSolver.leave_scope_with_scheme ~outer_env
+      ~tvars:(List.map snd targs) (Env.constraints env) sch;
     (e, sch)
 
   | EPolyFun([], named2, body) ->
@@ -133,29 +133,29 @@ let rec tr_poly_expr env named (e : S.poly_expr) =
     ExprUtils.generalize [] named body (T.Scheme.of_type tp)
 
   | EPolyFun(targs, named2, body) ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, targs) = Env.add_named_tvars env targs in
     let (env, named) = tr_named_params env (named @ named2) in
     let (body, tp, Checked) = infer_type env body (Check Pure) in
     let (e, sch) =
       ExprUtils.generalize targs named body (T.Scheme.of_type tp) in
-    ConstrSolver.leave_scope_with_scheme ~env0 ~tvars:(List.map snd targs)
-      (Env.constraints env) sch;
+    ConstrSolver.leave_scope_with_scheme ~outer_env
+      ~tvars:(List.map snd targs) (Env.constraints env) sch;
     (e, sch)
 
   | EGen([], named2, body) ->
     tr_poly_expr env (named @ named2) body
 
   | EGen(targs, named2, body) ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, targs) = Env.add_named_tvars env targs in
     let (body, sch) = tr_poly_expr env (named @ named2) body in
     let body = ExprUtils.mk_named_tfuns targs body in
     let sch = { sch with sch_targs = targs @ sch.sch_targs } in
-    ConstrSolver.leave_scope_with_scheme
-      ~env0 ~tvars:(List.map snd targs) (Env.constraints env) sch;
+    ConstrSolver.leave_scope_with_scheme ~outer_env
+      ~tvars:(List.map snd targs) (Env.constraints env) sch;
     (body, sch)
 
 (** Infer a scheme of a polymorphic expression. *)
@@ -165,13 +165,13 @@ and infer_scheme env e =
 (* ========================================================================= *)
 
 (** Translate and generalize a let-polymorphic expression. *)
-and tr_let_poly env x body =
-  let env0 = env in
-  let env = Env.enter_scope env in
-  let (e, sch) = infer_scheme env body in
+and tr_let_poly outer_env x body =
+  let inner_env = Env.enter_scope outer_env in
+  let (e, sch) = infer_scheme inner_env body in
   let (evs, cs) =
-    ConstrSolver.generalize_with_scheme ~env0 (Env.constraints env) sch in
-  let env = env0 in
+    ConstrSolver.generalize_with_scheme ~outer_env
+      (Env.constraints inner_env) sch in
+  let env = outer_env in
   match evs, cs with
   | [], [] ->
     let env = Env.add_poly_var env x sch in
@@ -183,14 +183,14 @@ and tr_let_poly env x body =
 
 (* ========================================================================= *)
 
-and tr_let_rec env targs named defs =
-  let env0 = env in
-  let env = Env.enter_scope env in
-  let (targs, named, defs) = tr_let_rec_defs env targs named defs in
+and tr_let_rec outer_env targs named defs =
+  let inner_env = Env.enter_scope outer_env in
+  let (targs, named, defs) = tr_let_rec_defs inner_env targs named defs in
   let (evs, cs) =
-    ConstrSolver.generalize_with_schemes ~env0 (Env.constraints env)
+    ConstrSolver.generalize_with_schemes ~outer_env
+      (Env.constraints inner_env)
       (List.map (fun (_, _, sch, _) -> sch) defs) in
-  let env = env0 in
+  let env = outer_env in
   let rec_ctx =
     ExprUtils.mk_rec_ctx ~evs ~cs ~targs ~named
       (List.map
@@ -211,14 +211,15 @@ and tr_let_rec_defs env targs named defs =
     ([], named, defs)
   
   | _ ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, targs) = Env.add_named_tvars env targs in
     let (env, named) = tr_named_params env named in
     let env = Env.enter_rec_context env in
     let (env, defs) = List.fold_left_map prepare_rec_def env defs in
     let defs = List.map (check_rec_def env targs named) defs in
-    ConstrSolver.leave_scope_with_schemes ~env0 ~tvars:(List.map snd targs)
+    ConstrSolver.leave_scope_with_schemes ~outer_env
+      ~tvars:(List.map snd targs)
       (Env.constraints env)
       (List.map (fun (_, _, sch, _) -> sch) defs);
     (targs, named, defs)
@@ -262,7 +263,7 @@ and check_scheme env (e : S.poly_fun) (sch : T.scheme) =
     ExprUtils.mk_fns xs body
 
   | PF_Fun(tvars, xs, body) ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     assert (List.length tvars = List.length sch.sch_targs);
     let ((env, sub), tvars) =
@@ -282,7 +283,7 @@ and check_scheme env (e : S.poly_fun) (sch : T.scheme) =
         (List.combine xs sch.sch_named) in
     let (body, Checked) =
       check_type env body (T.Type.subst sub sch.sch_body) (Check Pure) in
-    ConstrSolver.leave_scope ~env0 ~tvars (Env.constraints env);
+    ConstrSolver.leave_scope ~outer_env ~tvars (Env.constraints env);
     ExprUtils.mk_tfuns tvars (ExprUtils.mk_fns xs body)
 
   | PF_Hole hole ->
@@ -382,16 +383,16 @@ and infer_type : type ed.
     (T.ERecCtx e2, tp, eff_resp)
 
   | EData(dds, e2) ->
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, dds, tvars) = DataType.tr_data_defs env dds in
     let (e2, tp, eff_resp) = infer_type env e2 eff_req in
-    let res_tp = Subtyping.type_shape env0 tp in
+    let res_tp = Subtyping.type_shape ~outer_env tp in
     let eff = bidir_result eff_req eff_resp in
     let origin = ODataScope(e.pos, e.pp, tp, eff) in
     Subtyping.subtype ~origin env tp res_tp;
-    Subtyping.subceffect ~origin env eff (Impure (Env.fresh_gvar env0));
-    ConstrSolver.leave_scope_with_type_eff ~env0 ~tvars
+    Subtyping.subceffect ~origin env eff (Impure (Env.fresh_gvar outer_env));
+    ConstrSolver.leave_scope_with_type_eff ~outer_env ~tvars
       (Env.constraints env) res_tp eff;
     (T.EData(dds, e2), res_tp, eff_resp)
 
@@ -435,7 +436,7 @@ and infer_type : type ed.
     let (a, cap_tp, in_tp, in_eff, out_tp, out_eff) =
       Subtyping.as_handler tp1 in
     let eff_resp2 = return_effect env ~node:e eff_req (Impure out_eff) in
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, eff_var) = Env.add_tvar env eff_var in
     let sub = T.Subst.rename T.Subst.empty a eff_var in
@@ -444,22 +445,22 @@ and infer_type : type ed.
     let in_eff = T.Effct.subst sub in_eff in
     let env = Env.add_mono_var env x cap_tp in
     let (e2, Checked) = check_type env e2 in_tp (Check (Impure in_eff)) in
-    ConstrSolver.leave_scope ~env0 ~tvars:[eff_var] (Env.constraints env);
+    ConstrSolver.leave_scope ~outer_env ~tvars:[eff_var] (Env.constraints env);
     let res = ExprUtils.mk_handle eff_var x cap_tp e1 e2 in
     let eff_resp = eff_resp_join eff_resp1 [ eff_resp2 ] in
     (res, out_tp, eff_resp)
 
   | EHandler h ->
     (* create effect variable *)
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, eff_var) = Env.add_tvar env h.eff_var in
     (* Compute types and effects *)
     let delim_tp  = Type.tr_type env h.delim_tp in
-    let delim_eff = Env.fresh_gvar env0 in
+    let delim_eff = Env.fresh_gvar outer_env in
     let cap_tp    = Type.tr_type env h.cap_type in
     let in_tp     = Type.tr_type env h.body_tp in
-    let out_eff   = T.Effct.join (Env.fresh_gvar env0) delim_eff in
+    let out_eff   = T.Effct.join (Env.fresh_gvar outer_env) delim_eff in
     (* Add label *)
     let h_eff = T.Effct.var eff_var in
     let env = Env.add_mono_var env h.label
@@ -475,7 +476,7 @@ and infer_type : type ed.
     let (fin_body, fin_tp, Checked) =
       infer_type fin_env h.fin_body (Check (Impure out_eff)) in
     (* Compute output type *)
-    let out_tp  = Subtyping.type_shape env0 fin_tp in
+    let out_tp  = Subtyping.type_shape ~outer_env fin_tp in
     let origin =
       OHandlerScope(h.fin_body.pos, h.fin_body.pp, eff_var, fin_tp)
     in
@@ -484,7 +485,7 @@ and infer_type : type ed.
     let in_eff = T.Effct.join h_eff delim_eff in
     let tp = T.Type.t_handler eff_var cap_tp in_tp in_eff out_tp out_eff in
     (* Leave the scope, and return the result *)
-    ConstrSolver.leave_scope_with_type_eff ~env0 ~tvars:[eff_var]
+    ConstrSolver.leave_scope_with_type_eff ~outer_env ~tvars:[eff_var]
       (Env.constraints env) tp Pure;
     let res =
       ExprUtils.mk_handler
@@ -572,11 +573,11 @@ and tr_match_clause env pat_tp res_tp res_eff ((pat, body) : S.match_clause) =
 (** Translate a body of a match clause. *)
 and tr_match_clause_body ~pos env pat penv body tp eff =
   if Pattern.PEnv.has_existential penv then begin
-    let env0 = env in
+    let outer_env = env in
     let env = Env.enter_scope env in
     let (env, tvars, vars) = Pattern.PEnv.open_penv env penv in
     let (body, Checked) = check_type env body tp (Check eff) in
-    ConstrSolver.leave_scope ~env0 ~tvars (Env.constraints env);
+    ConstrSolver.leave_scope ~outer_env ~tvars (Env.constraints env);
     { PatternMatch.cl_pos   = pos;
       PatternMatch.cl_pat   = pat;
       PatternMatch.cl_body  = ExprUtils.mk_clause_body tvars vars body;

--- a/src/EffectInference/Subtyping.mli
+++ b/src/EffectInference/Subtyping.mli
@@ -16,10 +16,10 @@ val subtype : origin:origin -> Env.t -> T.typ -> T.typ -> unit
 val subscheme : origin:origin -> Env.t -> T.scheme -> T.scheme -> unit
 
 (** Create a type with the same shape as the given one, but with all effects
-  replaced with fresh generalizable variables at the scope of the environment.
-  The type might be later used with [subtype] function to ensure that type
-  variables don't escapes their scopes. *)
-val type_shape : Env.t -> T.typ -> T.typ
+  replaced with fresh generalizable variables at the outer scope (the scope of
+  [outer_env]). The type might be later used with [subtype] function to ensure
+  that type variables of the effect kind don't escape their scopes. *)
+val type_shape : outer_env:Env.t -> T.typ -> T.typ
 
 (** Decompose a type into components of an arrow type *)
 val as_arrow : T.typ -> T.scheme * T.typ * T.ceffect

--- a/src/Lang/ConE.mli
+++ b/src/Lang/ConE.mli
@@ -370,8 +370,8 @@ module Effct : sig
   val remove_gvar : gvar -> effct -> effct
 
   (** Collect all generalizable variables that do not belong to the given
-    scope and add them to the given set. *)
-  val collect_gvars : scope:Scope.t -> effct -> GVar.Set.t -> GVar.Set.t
+    (outer) scope and add them to the given set. *)
+  val collect_gvars : outer_scope:Scope.t -> effct -> GVar.Set.t -> GVar.Set.t
 
   (** Apply the substitution to the effect. *)
   val subst : subst -> effct -> effct
@@ -390,8 +390,9 @@ module CEffect : sig
   val join : ceffect -> ceffect -> ceffect
 
   (** Collect all generalizable variables that do not belong to the given
-    scope and add them to the given set. *)
-  val collect_gvars : scope:Scope.t -> ceffect -> GVar.Set.t -> GVar.Set.t
+    (outer) scope and add them to the given set. *)
+  val collect_gvars :
+    outer_scope:Scope.t -> ceffect -> GVar.Set.t -> GVar.Set.t
 end
 
 (* ========================================================================= *)
@@ -476,8 +477,8 @@ module Type : sig
   val to_effect : typ -> effct
 
   (** Collect all generalizable variables that do not belong to the given
-    scope and add them to the given set. *)
-  val collect_gvars : scope:Scope.t -> typ -> GVar.Set.t -> GVar.Set.t
+    (outer) scope and add them to the given set. *)
+  val collect_gvars : outer_scope:Scope.t -> typ -> GVar.Set.t -> GVar.Set.t
 
   (** Apply the substitution to the type. *)
   val subst : subst -> typ -> typ
@@ -500,14 +501,15 @@ module Scheme : sig
   val to_type : scheme -> typ option
 
   (** Collect all generalizable variables that do not belong to the given
-    scope and add them to the given set. *)
-  val collect_gvars : scope:Scope.t -> scheme -> GVar.Set.t -> GVar.Set.t
+    (outer) scope and add them to the given set. *)
+  val collect_gvars :
+    outer_scope:Scope.t -> scheme -> GVar.Set.t -> GVar.Set.t
 
   (** Collect all generalizable variables that do not belong to the given
-    scope and add the to the given sets, depending on their polarity. The
-    former set stores non-negative variables, while the latter stores
+    (outer) scope and add the to the given sets, depending on their polarity.
+    The former set stores non-negative variables, while the latter stores
     non-positive variables. Invariant variables are added to both sets. *)
-  val collect_gvars_p : scope:Scope.t -> scheme ->
+  val collect_gvars_p : outer_scope:Scope.t -> scheme ->
     GVar.Set.t * GVar.Set.t -> GVar.Set.t * GVar.Set.t
 
   (** Apply the substitution to the scheme. *)
@@ -521,8 +523,9 @@ end
 (** Operations on constructor declarations *)
 module CtorDecl : sig
   (** Collect all generalizable variables that do not belong to the given
-    scope and add them to the given set. *)
-  val collect_gvars : scope:Scope.t -> ctor_decl -> GVar.Set.t -> GVar.Set.t
+    (outer) scope and add them to the given set. *)
+  val collect_gvars :
+    outer_scope:Scope.t -> ctor_decl -> GVar.Set.t -> GVar.Set.t
 
   (** Apply the substitution to the constructor declaration. *)
   val subst : subst -> ctor_decl -> ctor_decl

--- a/src/Lang/ConEPriv/CEffect.ml
+++ b/src/Lang/ConEPriv/CEffect.ml
@@ -16,10 +16,10 @@ let join eff1 eff2 =
   | _, Pure -> eff1
   | Impure eff1, Impure eff2 -> Impure (Effct.join eff1 eff2)
 
-let collect_gvars ~scope eff gvs =
+let collect_gvars ~outer_scope eff gvs =
   match eff with
   | Pure       -> gvs
-  | Impure eff -> Effct.collect_gvars ~scope eff gvs
+  | Impure eff -> Effct.collect_gvars ~outer_scope eff gvs
 
 let to_sexpr eff =
   match eff with

--- a/src/Lang/ConEPriv/CEffect.mli
+++ b/src/Lang/ConEPriv/CEffect.mli
@@ -15,8 +15,9 @@ val prog_effect : t
 val join : t -> t -> t
 
 (** Collect all generalizable variables that do not belong to the given
-  scope and add them to the given set. *)
-val collect_gvars : scope:Scope.t -> t -> Effct.GVar.Set.t -> Effct.GVar.Set.t
+  (outer) scope and add them to the given set. *)
+val collect_gvars :
+  outer_scope:Scope.t -> t -> Effct.GVar.Set.t -> Effct.GVar.Set.t
 
 (** Pretty-print effect as S-expression *)
 val to_sexpr : t -> SExpr.t

--- a/src/Lang/ConEPriv/CtorDecl.ml
+++ b/src/Lang/ConEPriv/CtorDecl.ml
@@ -6,17 +6,17 @@
 
 open TypeBase
 
-let collect_gvars ~scope ctor gvs =
+let collect_gvars ~outer_scope ctor gvs =
   let { ctor_name = _; ctor_targs = _; ctor_named; ctor_arg_schemes } = ctor
   in
   let gvs =
     List.fold_left
-      (fun gvs (_, sch) -> Type.collect_scheme_gvars ~scope sch gvs)
+      (fun gvs (_, sch) -> Type.collect_scheme_gvars ~outer_scope sch gvs)
       gvs
       ctor_named
   in
   List.fold_left
-    (fun gvs sch -> Type.collect_scheme_gvars ~scope sch gvs)
+    (fun gvs sch -> Type.collect_scheme_gvars ~outer_scope sch gvs)
     gvs
     ctor_arg_schemes
 

--- a/src/Lang/ConEPriv/Effct.ml
+++ b/src/Lang/ConEPriv/Effct.ml
@@ -297,11 +297,11 @@ let filter_to_scope ~scope eff =
 
 (* ========================================================================= *)
 
-let collect_gvars ~scope eff gvs =
+let collect_gvars ~outer_scope eff gvs =
   let (_, gm) = view_map eff in
   GVarMap.fold
     (fun gv _ gvs ->
-      if GVar.in_scope gv scope then gvs
+      if GVar.in_scope gv outer_scope then gvs
       else GVar.Set.add gv gvs)
     gm
     gvs

--- a/src/Lang/ConEPriv/Effct.mli
+++ b/src/Lang/ConEPriv/Effct.mli
@@ -101,8 +101,8 @@ val remove_tvar : TVar.t -> t -> t
 val remove_gvar : gvar -> t -> t
 
 (** Collect all generalizable variables that do not belong to the given
-  scope and add them to the given set. *)
-val collect_gvars : scope:Scope.t -> t -> GVar.Set.t -> GVar.Set.t
+  (outer) scope and add them to the given set. *)
+val collect_gvars : outer_scope:Scope.t -> t -> GVar.Set.t -> GVar.Set.t
 
 (** Pretty-print the effect as an S-expression. *)
 val to_sexpr : t -> SExpr.t

--- a/src/Lang/ConEPriv/Type.ml
+++ b/src/Lang/ConEPriv/Type.ml
@@ -6,86 +6,86 @@
 
 open TypeBase
 
-let rec collect_gvars ~scope tp gvs =
+let rec collect_gvars ~outer_scope tp gvs =
   match view tp with
   | TVar x -> gvs
   | TArrow(sch, tp, eff) ->
-    collect_scheme_gvars ~scope sch gvs
-    |> collect_gvars ~scope tp
-    |> CEffect.collect_gvars ~scope eff
+    collect_scheme_gvars ~outer_scope sch gvs
+    |> collect_gvars ~outer_scope tp
+    |> CEffect.collect_gvars ~outer_scope eff
   | TLabel(eff, delim_tp, delim_eff) ->
-    Effct.collect_gvars ~scope eff gvs
-    |> collect_gvars ~scope delim_tp
-    |> Effct.collect_gvars ~scope delim_eff
+    Effct.collect_gvars ~outer_scope eff gvs
+    |> collect_gvars ~outer_scope delim_tp
+    |> Effct.collect_gvars ~outer_scope delim_eff
   | THandler { tvar = _; cap_tp; in_tp; in_eff; out_tp; out_eff } ->
-    collect_gvars ~scope cap_tp gvs
-    |> collect_gvars ~scope in_tp
-    |> Effct.collect_gvars ~scope in_eff
-    |> collect_gvars ~scope out_tp
-    |> Effct.collect_gvars ~scope out_eff
+    collect_gvars ~outer_scope cap_tp gvs
+    |> collect_gvars ~outer_scope in_tp
+    |> Effct.collect_gvars ~outer_scope in_eff
+    |> collect_gvars ~outer_scope out_tp
+    |> Effct.collect_gvars ~outer_scope out_eff
   | TEffect eff ->
-    Effct.collect_gvars ~scope eff gvs
+    Effct.collect_gvars ~outer_scope eff gvs
   | TApp(tp1, tp2) ->
-    collect_gvars ~scope tp1 gvs |> collect_gvars ~scope tp2
+    collect_gvars ~outer_scope tp1 gvs |> collect_gvars ~outer_scope tp2
   | TAlias(_, tp) ->
-    collect_gvars ~scope tp gvs
+    collect_gvars ~outer_scope tp gvs
 
-and collect_scheme_gvars ~scope sch gvs =
+and collect_scheme_gvars ~outer_scope sch gvs =
   List.fold_left
-    (fun gvs (_, sch) -> collect_scheme_gvars ~scope sch gvs)
+    (fun gvs (_, sch) -> collect_scheme_gvars ~outer_scope sch gvs)
     gvs
     sch.sch_named
-  |> collect_gvars ~scope sch.sch_body
+  |> collect_gvars ~outer_scope sch.sch_body
 
 (* ========================================================================= *)
 
 let swap_pair (x, y) = (y, x)
 
-let collect_effect_gvars_p ~scope eff (pgvs, ngvs) =
-  (Effct.collect_gvars ~scope eff pgvs, ngvs)
+let collect_effect_gvars_p ~outer_scope eff (pgvs, ngvs) =
+  (Effct.collect_gvars ~outer_scope eff pgvs, ngvs)
 
-let collect_effect_gvars_n ~scope eff (pgvs, ngvs) =
-  (pgvs, Effct.collect_gvars ~scope eff ngvs)
+let collect_effect_gvars_n ~outer_scope eff (pgvs, ngvs) =
+  (pgvs, Effct.collect_gvars ~outer_scope eff ngvs)
 
-let collect_ceffect_gvars_p ~scope eff (pgvs, ngvs) =
-  (CEffect.collect_gvars ~scope eff pgvs, ngvs)
+let collect_ceffect_gvars_p ~outer_scope eff (pgvs, ngvs) =
+  (CEffect.collect_gvars ~outer_scope eff pgvs, ngvs)
 
-let collect_gvars_i ~scope tp (pgvs, ngvs) =
-  let gvs = collect_gvars ~scope tp Effct.GVar.Set.empty in
+let collect_gvars_i ~outer_scope tp (pgvs, ngvs) =
+  let gvs = collect_gvars ~outer_scope tp Effct.GVar.Set.empty in
   (Effct.GVar.Set.union gvs pgvs, Effct.GVar.Set.union gvs ngvs)
 
-let rec collect_gvars_p ~scope tp gvsp =
+let rec collect_gvars_p ~outer_scope tp gvsp =
   match view tp with
   | TVar x -> gvsp
   | TArrow(sch, tp, eff) ->
-    collect_scheme_gvars_n ~scope sch gvsp
-    |> collect_gvars_p ~scope tp
-    |> collect_ceffect_gvars_p ~scope eff
+    collect_scheme_gvars_n ~outer_scope sch gvsp
+    |> collect_gvars_p ~outer_scope tp
+    |> collect_ceffect_gvars_p ~outer_scope eff
   | THandler { tvar = _; cap_tp; in_tp; in_eff; out_tp; out_eff } ->
-    collect_gvars_p ~scope cap_tp gvsp
-    |> collect_gvars_n ~scope in_tp
-    |> collect_effect_gvars_n ~scope in_eff
-    |> collect_gvars_p ~scope out_tp
-    |> collect_effect_gvars_p ~scope out_eff
+    collect_gvars_p ~outer_scope cap_tp gvsp
+    |> collect_gvars_n ~outer_scope in_tp
+    |> collect_effect_gvars_n ~outer_scope in_eff
+    |> collect_gvars_p ~outer_scope out_tp
+    |> collect_effect_gvars_p ~outer_scope out_eff
   | TLabel _ | TApp _ ->
-    collect_gvars_i ~scope tp gvsp
+    collect_gvars_i ~outer_scope tp gvsp
   | TAlias(_, tp) ->
-    collect_gvars_p ~scope tp gvsp
+    collect_gvars_p ~outer_scope tp gvsp
   
   | TEffect _ -> failwith "Internal kind error"
 
-and collect_gvars_n ~scope tp gvsp =
-  gvsp |> swap_pair |> collect_gvars_p ~scope tp |> swap_pair
+and collect_gvars_n ~outer_scope tp gvsp =
+  gvsp |> swap_pair |> collect_gvars_p ~outer_scope tp |> swap_pair
 
-and collect_scheme_gvars_p ~scope sch gvsp =
+and collect_scheme_gvars_p ~outer_scope sch gvsp =
   List.fold_left
-    (fun gvsp (_, sch) -> collect_scheme_gvars_n ~scope sch gvsp)
+    (fun gvsp (_, sch) -> collect_scheme_gvars_n ~outer_scope sch gvsp)
     gvsp
     sch.sch_named
-  |> collect_gvars_p ~scope sch.sch_body
+  |> collect_gvars_p ~outer_scope sch.sch_body
 
-and collect_scheme_gvars_n ~scope sch gvsp =
-  gvsp |> swap_pair |> collect_scheme_gvars_p ~scope sch |> swap_pair
+and collect_scheme_gvars_n ~outer_scope sch gvsp =
+  gvsp |> swap_pair |> collect_scheme_gvars_p ~outer_scope sch |> swap_pair
 
 (* ========================================================================= *)
 

--- a/src/TypeInference/Def.ml
+++ b/src/TypeInference/Def.ml
@@ -128,7 +128,7 @@ let check_def : type st dir. tcfix:tcfix ->
     }
 
   | DHandlePat(pat, heff, hexp) ->
-    let env0 = env in
+    let outer_env = env in
     let (hexp_env, params) = Env.begin_generalize env in
     let hexp = infer_expr_type hexp_env hexp in
     let hexp_tp = expr_result_type hexp in
@@ -153,9 +153,9 @@ let check_def : type st dir. tcfix:tcfix ->
         match req with
         | Infer    -> Infered tp_out
         | Check tp ->
-          let pp = Env.pp_tree env0 in
+          let pp = Env.pp_tree outer_env in
           Error.check_unify_result ~pos
-            (Unification.subtype env0 tp_out tp)
+            (Unification.subtype outer_env tp_out tp)
             ~on_error:(Error.expr_type_mismatch ~pp tp_out tp);
           Checked
       in


### PR DESCRIPTION
This PR renames variables and named parameters that refers to the outer scope/outer environment at the place of generalization to a name that better describes what they are.

This change was originally suggested by [@Foxinio](https://github.com/fram-lang/dbl/pull/276#discussion_r2538252115).