### PR TITLE
Fixed bug in simplification of subeffecting constraints

### DIFF
--- a/test/ok/ok0147_handlePure.fram
+++ b/test/ok/ok0147_handlePure.fram
@@ -1,0 +1,6 @@
+data T (E : effect) = X
+
+let h = handler X end
+
+let foo (bar : {E, ~n : T E} -> Unit ->[] Unit) =
+  handle ~n with h in bar ()


### PR DESCRIPTION
Fixed bug in constraint simplification. Additionally, S-expression printers for the internal representation of constraints were implemented, in order to help potential future debugging of the constraint simplification procedure.