### PR TITLE
Simple profiling for the pipeline

### DIFF
--- a/src/Pipeline.ml
+++ b/src/Pipeline.ml
@@ -56,7 +56,7 @@ let core_pipeline prog =
   |> dump_sexpr !dump_core Lang.Core.to_sexpr
   |> check_invariant true
        (print_timing "second type check" Lang.Core.check_well_typed)
-  |> CoreTypeErase.tr_program
+  |> print_timing "type erasure" CoreTypeErase.tr_program
   |> print_timing "evaluation" Eval.eval_program
 
 let nocore_pipeline prog =
@@ -65,7 +65,7 @@ let nocore_pipeline prog =
   |> print_timing "effect inference"
        (EffectInference.Main.tr_program ~solve_all:false)
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
-  |> ConETypeErase.tr_program
+  |> print_timing "type erasure" ConETypeErase.tr_program
   |> print_timing "evaluation" Eval.eval_program
 
 let run_repl () =

--- a/src/Pipeline.ml
+++ b/src/Pipeline.ml
@@ -11,10 +11,19 @@ let use_prelude = ref true
 
 let use_stdlib = ref true
 
+let timings = ref false
+
 let dump_sexpr flag to_sexpr p =
   if flag then
     SExpr.pretty_stdout (to_sexpr p);
   p
+
+let print_timing label f arg =
+    if not !timings then f arg else
+        let start = Unix.gettimeofday () in
+        let r = f arg in
+        Printf.eprintf "[timing] %s:  %.3fs\n" label (Unix.gettimeofday () -. start);
+        r
 
 let check_invariant check inv p =
   if check
@@ -34,22 +43,22 @@ let set_module_dirs ?fname () =
 
 let core_pipeline prog =
   prog
-  |> TypeInference.Main.tr_program
-  |> EffectInference.Main.tr_program ~solve_all:true
+  |> print_timing "type inference" TypeInference.Main.tr_program
+  |> print_timing "effect inference" (EffectInference.Main.tr_program ~solve_all:true)
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
-  |> ToCore.Main.tr_program
+  |> print_timing "to core" ToCore.Main.tr_program
   |> dump_sexpr !dump_core Lang.Core.to_sexpr
-  |> check_invariant true Lang.Core.check_well_typed
+  |> print_timing "second type check" (check_invariant true Lang.Core.check_well_typed)
   |> CoreTypeErase.tr_program
-  |> Eval.eval_program
+  |> print_timing "evaluation" Eval.eval_program
 
 let nocore_pipeline prog =
   prog
-  |> TypeInference.Main.tr_program
-  |> EffectInference.Main.tr_program ~solve_all:false
+  |> print_timing "type inference" TypeInference.Main.tr_program
+  |> print_timing "effect inference" (EffectInference.Main.tr_program ~solve_all:false)
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
   |> ConETypeErase.tr_program
-  |> Eval.eval_program
+  |> print_timing "evaluation" Eval.eval_program
 
 let run_repl () =
   set_module_dirs ();

--- a/src/Pipeline.ml
+++ b/src/Pipeline.ml
@@ -22,9 +22,13 @@ let print_timing label f arg =
   if not !timings then f arg
   else
     let start = Unix.gettimeofday () in
-    let r = f arg in
-    Printf.eprintf "[timing] %s:  %.3fs\n" label (Unix.gettimeofday () -. start);
-    r
+    let at_end () =
+      Printf.eprintf "[timing] %s:  %.3fs\n%!" label
+        (Unix.gettimeofday () -. start)
+    in
+    match f arg with
+    | r -> at_end (); r
+    | exception ex -> at_end (); raise ex
 
 let check_invariant check inv p =
   if check
@@ -50,8 +54,8 @@ let core_pipeline prog =
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
   |> print_timing "to core" ToCore.Main.tr_program
   |> dump_sexpr !dump_core Lang.Core.to_sexpr
-  |> print_timing "second type check"
-       (check_invariant true Lang.Core.check_well_typed)
+  |> check_invariant true
+       (print_timing "second type check" Lang.Core.check_well_typed)
   |> CoreTypeErase.tr_program
   |> print_timing "evaluation" Eval.eval_program
 

--- a/src/Pipeline.ml
+++ b/src/Pipeline.ml
@@ -19,11 +19,12 @@ let dump_sexpr flag to_sexpr p =
   p
 
 let print_timing label f arg =
-    if not !timings then f arg else
-        let start = Unix.gettimeofday () in
-        let r = f arg in
-        Printf.eprintf "[timing] %s:  %.3fs\n" label (Unix.gettimeofday () -. start);
-        r
+  if not !timings then f arg
+  else
+    let start = Unix.gettimeofday () in
+    let r = f arg in
+    Printf.eprintf "[timing] %s:  %.3fs\n" label (Unix.gettimeofday () -. start);
+    r
 
 let check_invariant check inv p =
   if check
@@ -44,18 +45,21 @@ let set_module_dirs ?fname () =
 let core_pipeline prog =
   prog
   |> print_timing "type inference" TypeInference.Main.tr_program
-  |> print_timing "effect inference" (EffectInference.Main.tr_program ~solve_all:true)
+  |> print_timing "effect inference"
+       (EffectInference.Main.tr_program ~solve_all:true)
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
   |> print_timing "to core" ToCore.Main.tr_program
   |> dump_sexpr !dump_core Lang.Core.to_sexpr
-  |> print_timing "second type check" (check_invariant true Lang.Core.check_well_typed)
+  |> print_timing "second type check"
+       (check_invariant true Lang.Core.check_well_typed)
   |> CoreTypeErase.tr_program
   |> print_timing "evaluation" Eval.eval_program
 
 let nocore_pipeline prog =
   prog
   |> print_timing "type inference" TypeInference.Main.tr_program
-  |> print_timing "effect inference" (EffectInference.Main.tr_program ~solve_all:false)
+  |> print_timing "effect inference"
+       (EffectInference.Main.tr_program ~solve_all:false)
   |> dump_sexpr !dump_cone Lang.ConE.to_sexpr
   |> ConETypeErase.tr_program
   |> print_timing "evaluation" Eval.eval_program

--- a/src/Pipeline.mli
+++ b/src/Pipeline.mli
@@ -16,10 +16,10 @@ val use_prelude : bool ref
 (** Include the standard library only if this flag is set. *)
 val use_stdlib : bool ref
 
-(** Print time profiling messages if this flag is set *)
+(** Print time profiling messages if this flag is set. *)
 val timings : bool ref
 
-(** Run in REPL mode *)
+(** Run in REPL mode. *)
 val run_repl : unit -> unit
 
 (** Run single file as a program. It takes file path as a parameter. *)

--- a/src/Pipeline.mli
+++ b/src/Pipeline.mli
@@ -16,6 +16,9 @@ val use_prelude : bool ref
 (** Include the standard library only if this flag is set. *)
 val use_stdlib : bool ref
 
+(** Print time profiling messages if this flag is set *)
+val timings : bool ref
+
 (** Run in REPL mode *)
 val run_repl : unit -> unit
 

--- a/src/dbl.ml
+++ b/src/dbl.ml
@@ -37,6 +37,10 @@ let cmd_args_options = Arg.align
     Arg.Clear Pipeline.use_stdlib,
     " Do not use the standard library";
 
+    "-timings",
+    Arg.Set Pipeline.timings,
+    " Print timings of pipeline stages";
+
     "-verbose-internal-errors",
     Arg.Set InterpLib.InternalError.verbose,
     " Make internal errors more verbose (for debugging only)";

--- a/src/dbl.ml
+++ b/src/dbl.ml
@@ -39,7 +39,7 @@ let cmd_args_options = Arg.align
 
     "-timings",
     Arg.Set Pipeline.timings,
-    " Print timings of pipeline stages";
+    " Print timings of pipeline stages to stderr";
 
     "-verbose-internal-errors",
     Arg.Set InterpLib.InternalError.verbose,


### PR DESCRIPTION
#293
Add a `-timings` flag which prints timings of execution of each pipeline step.
They are printed to stderr to separate them from the program's output.