### PR TITLE
Homogeneous types of selected arithmetic operators

### DIFF
--- a/lib/Base/Operators.fram
+++ b/lib/Base/Operators.fram
@@ -6,10 +6,10 @@ parameter T
 parameter type U
 parameter type E
 
-pub let (- .) {method neg : T ->[E] U} (x : T) = x.neg
+pub let (- .) {method neg : T ->[E] T} (x : T) = x.neg
 
-pub let (+) {method add : T -> U} (x : T) = x.add
-pub let (-) {method sub : T -> U} (x : T) = x.sub
+pub let (+) {method add : T -> T ->[E] T} (x : T) = x.add
+pub let (-) {method sub : T -> T ->[E] T} (x : T) = x.sub
 pub let (%)
   { ~__line__, ~__file__
   , method mod : {~__line__, ~__file__} -> T -> U} (x : T) =
@@ -24,16 +24,16 @@ pub let (**)
   , method pow : {~__line__, ~__file__} -> T -> U} (x : T) =
     x.pow
 
-pub let (==) {method equal : T -> U} (x : T) = x.equal
-pub let (!=) {method neq   : T -> U} (x : T) = x.neq
-pub let (>)  {method gt    : T -> U} (x : T) = x.gt
-pub let (>=) {method ge    : T -> U} (x : T) = x.ge
-pub let (<)  {method lt    : T -> U} (x : T) = x.lt
-pub let (<=) {method le    : T -> U} (x : T) = x.le
+pub let (==) {method equal : T -> T ->[E] U} (x : T) = x.equal
+pub let (!=) {method neq   : T -> T ->[E] U} (x : T) = x.neq
+pub let (>)  {method gt    : T -> T ->[E] U} (x : T) = x.gt
+pub let (>=) {method ge    : T -> T ->[E] U} (x : T) = x.ge
+pub let (<)  {method lt    : T -> T ->[E] U} (x : T) = x.lt
+pub let (<=) {method le    : T -> T ->[E] U} (x : T) = x.le
 
-pub let (&&&) {method land    : T -> U} (x : T) = x.land
-pub let (^^^) {method lxor    : T -> U} (x : T) = x.lxor
-pub let (|||) {method lor     : T -> U} (x : T) = x.lor
+pub let (&&&) {method land    : T -> T ->[E] T} (x : T) = x.land
+pub let (^^^) {method lxor    : T -> T ->[E] T} (x : T) = x.lxor
+pub let (|||) {method lor     : T -> T ->[E] T} (x : T) = x.lor
 pub let (<<)  {method shiftl  : T -> U} (x : T) = x.shiftl
 pub let (>>)  {method shiftr  : T -> U} (x : T) = x.shiftr
 pub let (>>>) {method ashiftr : T -> U} (x : T) = x.ashiftr


### PR DESCRIPTION
This commit changes types of additive, comparison, and bitwise operators to more homogeneous. Homogeneous types are more restrictive, but works better with type reconstruction. Multiplicative and bit-shift operators are left heterogeneous, because there are cases where it is useful (e.g., function composition or file path extending).

Fixes #316