### PR TITLE
The standard effect of throwing exceptions

### DIFF
--- a/lib/Exception.fram
+++ b/lib/Exception.fram
@@ -10,16 +10,16 @@ handler for it.
 ##}
 
 {## The effect capability for exceptions. ##}
-pub data Exception E X =
+pub data Exn E Arg =
   {## Raise an exception. ##}
-  { raise : {Y} -> X ->[E] Y
+  { raise : {X} -> Arg ->[E] X
   }
 
 {## The first-class handler for exceptions.
 
 It calls given function `f` when an exception is raised.
 ##}
-pub let hException {X} f =
+pub let hExn {Arg} f =
   handler
-    Exception { X, effect raise x = f x }
+    Exn { Arg, effect raise x = f x }
   end

--- a/lib/Exception.fram
+++ b/lib/Exception.fram
@@ -21,5 +21,5 @@ It calls given function `f` when an exception is raised.
 ##}
 pub let hException f =
   handler
-    Exception { effect raise x => f x }
+    Exception { effect raise x = f x }
   end

--- a/lib/Exception.fram
+++ b/lib/Exception.fram
@@ -19,7 +19,7 @@ pub data Exception E X =
 
 It calls given function `f` when an exception is raised.
 ##}
-pub let hException f =
+pub let hException {X} f =
   handler
-    Exception { effect raise x = f x }
+    Exception { X, effect raise x = f x }
   end

--- a/lib/Exception.fram
+++ b/lib/Exception.fram
@@ -1,0 +1,25 @@
+{# This file is part of DBL, released under MIT license.
+ # See LICENSE for details.
+ #}
+
+## # Exceptions
+
+{##
+This module defines the effect capability for exceptions, and a first-class
+handler for it.
+##}
+
+{## The effect capability for exceptions. ##}
+pub data Exception E X =
+  {## Raise an exception. ##}
+  { raise : {Y} -> X ->[E] Y
+  }
+
+{## The first-class handler for exceptions.
+
+It calls given function `f` when an exception is raised.
+##}
+pub let hException f =
+  handler
+    Exception { effect raise x => f x }
+  end

--- a/test/stdlib/Exception.fram
+++ b/test/stdlib/Exception.fram
@@ -3,20 +3,20 @@ import open /Exception
 
 let _ = testCase "normal return" (fn _ =>
   let result =
-    handle _ with hException {X=Bool} (fn _ => -1) in 42
+    handle _ with hExn {Arg=Bool} (fn _ => -1) in 42
   in
   assertEq result 42)
 
 let _ = testCase "raise" (fn _ =>
   let result =
-    handle exn with hException {X=Int} (fn x => x.toString) in
+    handle exn with hExn {Arg=Int} (fn x => x.toString) in
     exn.raise 5
   in
   assertEq result "5")
 
 let _ = testCase "raise is polymorphic" (fn _ =>
   let result =
-    handle exn with hException (fn _ => 13) in
+    handle exn with hExn (fn _ => 13) in
     if exn.raise () then exn.raise () else 42
   in
   assertEq result 13)
@@ -24,7 +24,7 @@ let _ = testCase "raise is polymorphic" (fn _ =>
 let _ = testCase "handler executed once" (fn _ =>
   let count = ~mut.ref 0 in
   let _ =
-    handle exn with hException (fn _ => count := count.get + 1) in
+    handle exn with hExn (fn _ => count := count.get + 1) in
     exn.raise ();
     exn.raise ()
   in
@@ -32,8 +32,8 @@ let _ = testCase "handler executed once" (fn _ =>
 
 let _ = testCase "cascade" (fn _ =>
   let result =
-    handle exn1 with hException (fn s => "1" + s)
-    handle exn2 with hException (fn s => exn1.raise ("2" + s))
+    handle exn1 with hExn (fn s => "1" + s)
+    handle exn2 with hExn (fn s => exn1.raise ("2" + s))
     in
     exn2.raise "raise"
   in
@@ -41,8 +41,8 @@ let _ = testCase "cascade" (fn _ =>
 
 let _ = testCase "skip inner handler" (fn _ =>
   let result =
-    handle exn with hException (fn _ => "outer")
-    handle _ with hException {X=String} (fn _ => "inner") in
+    handle exn with hExn (fn _ => "outer")
+    handle _ with hExn {Arg=String} (fn _ => "inner") in
     exn.raise "error"
   in
   assertEqS result "outer")

--- a/test/stdlib/Exception.fram
+++ b/test/stdlib/Exception.fram
@@ -1,0 +1,48 @@
+import open Testing
+import open /Exception
+
+let _ = testCase "normal return" (fn _ =>
+  let result =
+    handle _ with hException {X=Bool} (fn _ => -1) in 42
+  in
+  assertEq result 42)
+
+let _ = testCase "raise" (fn _ =>
+  let result =
+    handle exn with hException {X=Int} (fn x => x.toString) in
+    exn.raise 5
+  in
+  assertEq result "5")
+
+let _ = testCase "raise is polymorphic" (fn _ =>
+  let result =
+    handle exn with hException (fn _ => 13) in
+    if exn.raise () then exn.raise () else 42
+  in
+  assertEq result 13)
+
+let _ = testCase "handler executed once" (fn _ =>
+  let count = ~mut.ref 0 in
+  let _ =
+    handle exn with hException (fn _ => count := count.get + 1) in
+    exn.raise ();
+    exn.raise ()
+  in
+  assertEq count.get 1)
+
+let _ = testCase "cascade" (fn _ =>
+  let result =
+    handle exn1 with hException (fn s => "1" + s)
+    handle exn2 with hException (fn s => exn1.raise ("2" + s))
+    in
+    exn2.raise "raise"
+  in
+  assertEqS result "12raise")
+
+let _ = testCase "skip inner handler" (fn _ =>
+  let result =
+    handle exn with hException (fn _ => "outer")
+    handle _ with hException {X=String} (fn _ => "inner") in
+    exn.raise "error"
+  in
+  assertEqS result "outer")

--- a/test/stdlib/TestAll.fram
+++ b/test/stdlib/TestAll.fram
@@ -10,4 +10,5 @@ import Map
 import Mutable
 import Prelude
 import State
+import Exception
 import String


### PR DESCRIPTION
This PR provides standard effect capability of throwing exceptions together with a simple first-class handler. It is not clear to me, if the exceptions should be named `Exception` or just `Exn`.