### PR TITLE
Fixed `Base/*` visibility

### DIFF
--- a/lib/Base/Int64.fram
+++ b/lib/Base/Int64.fram
@@ -61,6 +61,9 @@ pub method min (self : Int64) oth =
 pub method max (self : Int64) oth =
   if self >= oth then self else oth
 
+pub let ofInt n = (extern dbl_intToInt64 : Int -> Int64) n
+
+pub let zero = 0L
+pub let one  = 1L
 pub let maxValue = 9223372036854775807L
-# Workaround due to issue #340
 pub let minValue = -9223372036854775807L - 1L

--- a/lib/Base/Int64.fram
+++ b/lib/Base/Int64.fram
@@ -62,4 +62,5 @@ pub method max (self : Int64) oth =
   if self >= oth then self else oth
 
 pub let maxValue = 9223372036854775807L
-pub let minValue = maxValue + 1L
+# Workaround due to issue #340
+pub let minValue = -9223372036854775807L - 1L

--- a/lib/Base/Int64.fram
+++ b/lib/Base/Int64.fram
@@ -60,3 +60,6 @@ pub method min (self : Int64) oth =
   if self <= oth then self else oth
 pub method max (self : Int64) oth =
   if self >= oth then self else oth
+
+pub let maxValue = 9223372036854775807L
+pub let minValue = maxValue + 1L

--- a/lib/Prelude.fram
+++ b/lib/Prelude.fram
@@ -13,6 +13,7 @@ import /Base/Char
 import /Base/String
 import /Base/Show
 import /Base/Pair
+import /Base/Result
 
 pub open Types
 pub open Operators
@@ -46,7 +47,12 @@ pub let readLine = extern dbl_readLine : Unit ->[IO] String
 
 pub let exit {type X} = extern dbl_exit : Int ->[IO] X
 
+pub module Int
+  pub open Int
+end
+
 pub module Int64
+  pub open Int64
   pub let zero = 0L
   pub let one  = 1L
   pub let ofInt (n : Int) = n.toInt64
@@ -64,7 +70,7 @@ pub let min {T, method lt : T -> T ->> Bool} (x : T) (y : T) =
 pub let strListCat = extern dbl_strListCat : List String -> String
 
 ## Creates a string with `n` repetitions.
-pub let rec replicate (s : String) (n : Int) = 
+pub let rec replicate (s : String) (n : Int) =
   if n <= 0 then
     ""
   else if n % 2 == 0 then

--- a/lib/Prelude.fram
+++ b/lib/Prelude.fram
@@ -53,9 +53,6 @@ end
 
 pub module Int64
   pub open Int64
-  pub let zero = 0L
-  pub let one  = 1L
-  pub let ofInt (n : Int) = n.toInt64
 end
 
 ## Returns the greater of two elements `x` and `y`.


### PR DESCRIPTION
Fixed visibility of some values defined in `Base/*` and added definitions of minimal and maximal values of `Int64`.
Closes #313 .