### PR TITLE
Handle non-total handlers

### DIFF
--- a/src/EffectInference/Expr.ml
+++ b/src/EffectInference/Expr.ml
@@ -466,7 +466,8 @@ and infer_type : type ed.
     let env = Env.add_mono_var env h.label
       (T.Type.t_label h_eff delim_tp delim_eff) in
     (* Translate the capability *)
-    let (cap_body, Checked) = check_type env h.cap_body cap_tp (Check Pure) in
+    let (cap_body, Checked) =
+      check_type env h.cap_body cap_tp (Check (Impure out_eff)) in
     (* Translate the return clause *)
     let ret_env = Env.add_mono_var env h.ret_var in_tp in
     let (ret_body, Checked) =

--- a/src/EffectInference/ExprUtils.ml
+++ b/src/EffectInference/ExprUtils.ml
@@ -102,6 +102,7 @@ let mk_handler
     ~eff_var ~lbl_var ~delim_tp ~delim_eff ~cap_tp ~in_tp ~in_eff 
     ~cap_body ~ret_var ~ret_body ~fin_var ~fin_body () =
   let comp_var = Var.fresh ~name:"comp" () in
+  let cap_var = Var.fresh ~name:"cap" () in
   let sch =
     { T.sch_targs = [(TNAnon, eff_var)];
       T.sch_named = [];
@@ -119,9 +120,11 @@ let mk_handler
   T.EFn(comp_var, sch,
     T.EData([label_dd],
       T.ELet(fin_var,
-        T.EReset(T.EVar lbl_var,
-          T.EApp(T.ETApp(T.EVar comp_var, T.Type.t_var eff_var), cap_body),
-          ret_var, ret_body),
+        T.ELet(cap_var, cap_body,
+          T.EReset(T.EVar lbl_var,
+            T.EApp(T.ETApp(T.EVar comp_var, T.Type.t_var eff_var),
+              (T.EVar cap_var)),
+            ret_var, ret_body)),
         fin_body)))
 
 (* ========================================================================= *)

--- a/src/Lang/Unif.mli
+++ b/src/Lang/Unif.mli
@@ -419,7 +419,7 @@ and expr_data =
 
       cap_body  : expr;
       (** An expression that should evaluate to effect capability. It can use
-        [label] and [effect]. It should be pure and have type [cap_type]. *)
+        [label] and [effect]. It should have the type [cap_type]. *)
 
       ret_var   : var;
       (** An argument to the return clause *)

--- a/src/TypeInference/Error.ml
+++ b/src/TypeInference/Error.ml
@@ -200,11 +200,6 @@ let func_not_total ~pos =
   (pos, "Cannot ensure that this function is total "
     ^ "(pure and terminating)", [])
 
-let handler_not_total ~pos =
-  (pos,
-    "Cannot ensure that this handler expression is total "
-    ^ "(pure and terminating)", [])
-
 let expr_not_total ~pos =
   (pos, "Cannot ensure that this expression is total "
     ^ "(pure and terminating)", [])

--- a/src/TypeInference/Error.mli
+++ b/src/TypeInference/Error.mli
@@ -58,7 +58,6 @@ val repl_show_type_mismatch :
   pos:Position.t -> pp:PPTree.t -> self_tp:T.typ -> T.typ -> t
 
 val func_not_total : pos:Position.t -> t
-val handler_not_total : pos:Position.t -> t
 val expr_not_total : pos:Position.t -> t
 
 val invalid_rec_def : pos:Position.t -> t

--- a/src/TypeInference/Expr.ml
+++ b/src/TypeInference/Expr.ml
@@ -122,10 +122,6 @@ let infer_expr_type ~tcfix ?app_type env (e : S.expr) =
     let delim_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     let (env, lx) = Env.add_the_label env (T.Type.t_label delim_tp) in
     let er_cap = infer_expr_type env cap in
-    begin match er_cap.er_effect with
-    | Pure -> ()
-    | Impure -> Error.report (Error.handler_not_total ~pos)
-    end;
     let cap_tp = expr_result_type er_cap in
     let body_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
     let fin_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
@@ -363,10 +359,6 @@ let check_expr_type ~tcfix env (e : S.expr) tp =
       let delim_tp = Env.fresh_uvar ~pos env T.Kind.k_type in
       let (env, lx) = Env.add_the_label env (T.Type.t_label delim_tp) in
       let er_cap = check_expr_type env cap cap_tp in
-      begin match er_cap.er_effect with
-      | Pure -> ()
-      | Impure -> Error.report (Error.handler_not_total ~pos)
-      end;
       let (ret_x, er_ret) =
         MatchClause.tr_return_clauses ~tcfix ~pos env tp_in rcs
           (Check delim_tp) in

--- a/test/ok/ok0159_nontotal_handler.fram
+++ b/test/ok/ok0159_nontotal_handler.fram
@@ -1,0 +1,7 @@
+let hId = handler effect x => resume x end
+
+handle (id : Unit ->> Unit) with hId
+
+let hConst x = handler id (); effect _ => resume x end
+
+let x = handle get with hConst 42 in get ()


### PR DESCRIPTION
This makes the usual first-class handlers consistent with handlers from handling functions in #335 by not requiring totality for the effect capability.