### PR TITLE
Support for affine effects in stdlib

### DIFF
--- a/lib/Exception.fram
+++ b/lib/Exception.fram
@@ -12,7 +12,7 @@ handler for it.
 {## The effect capability for exceptions. ##}
 pub data Exn E Arg =
   {## Raise an exception. ##}
-  { raise : {X} -> Arg ->[E] X
+  { raise : {X} -> Arg ->[aff E] X
   }
 
 {## The first-class handler for exceptions.
@@ -21,5 +21,5 @@ It calls given function `f` when an exception is raised.
 ##}
 pub let hExn {Arg} f =
   handler
-    Exn { Arg, effect raise x = f x }
+    Exn { Arg, aff effect raise x = f x }
   end

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -76,8 +76,8 @@ pub let ioMut = Mut {E=IO}
 {## Local handler of state.
 
   The mutability effect can be handled locally, provided that the handled
-  computation has no other effects. ##}
-pub let hMut (f : {E : effect} -> Mut E ->[E] _) =
+  computation's effects are affine. ##}
+pub let hMut {type R} (f : {E : effect} -> Mut E ->[E, aff R] _) =
   handle _ / E = () in
   f {E} Mut
 
@@ -86,7 +86,7 @@ pub let hMut (f : {E : effect} -> Mut E ->[E] _) =
   This function is similar to `hMut`, but it allows the handled expression to
   have other effects. However, this function is not pure: it has the `IO`
   effect. ##}
-pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[E,R] _) =
+pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[aff E,R] _) =
   f {E=IO} ioMut
 
 {# ========================================================================= #}
@@ -97,15 +97,15 @@ pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[E,R] _) =
 
 {## Get the contents of a mutable value. ##}
 pub method get {E, type T} =
-  extern dbl_refGet : Ref E T ->[E] T
+  extern dbl_refGet : Ref E T ->[aff E] T
 
 {## Set the contents of a mutable value. ##}
 pub method set {E, type T} =
-  extern dbl_refSet : Ref E T -> T ->[E] Unit
+  extern dbl_refSet : Ref E T -> T ->[aff E] Unit
 
 {## Create a new mutable cell. ##}
 pub method ref {E, type T} (self : Mut E) =
-  extern dbl_ref : T ->[E] Ref E T
+  extern dbl_ref : T ->[aff E] Ref E T
 
 {# ========================================================================= #}
 ## ## Mutable arrays
@@ -119,13 +119,13 @@ pub method ref {E, type T} (self : Mut E) =
 pub data ArrayElem E T = { set : T ->[E] Unit }
 
 let unsafeGetArray {E, type T} =
-  extern dbl_arrayGet : Array E T -> Int ->[E] T
+  extern dbl_arrayGet : Array E T -> Int ->[aff E] T
 
 let unsafeSetArray {E, type T} =
-  extern dbl_arraySet : Array E T -> Int -> T ->[E] Unit
+  extern dbl_arraySet : Array E T -> Int -> T ->[aff E] Unit
 
 let unsafeMakeArray {E, type T} =
-  extern dbl_mkArray : Int ->[E] Array E T
+  extern dbl_mkArray : Int ->[aff E] Array E T
 
 {## Get the maximum length of an array. ##}
 pub let maxArrayLength = (extern dbl_maxArrayLength : Int)

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -77,7 +77,7 @@ pub let ioMut = Mut {E=IO}
 
   The mutability effect can be handled locally, provided that the handled
   computation's effects are affine. ##}
-pub let hMut {type R} (f : {E : effect} -> Mut E ->[E, aff R] _) =
+pub let hMut {type R} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
   handle _ / E = () in
   f {E} Mut
 
@@ -86,7 +86,7 @@ pub let hMut {type R} (f : {E : effect} -> Mut E ->[E, aff R] _) =
   This function is similar to `hMut`, but it allows the handled expression to
   have other effects. However, this function is not pure: it has the `IO`
   effect. ##}
-pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[aff E,R] _) =
+pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
   f {E=IO} ioMut
 
 {# ========================================================================= #}
@@ -116,7 +116,7 @@ pub method ref {E, type T} (self : Mut E) =
 {## Write-only elements of an array.
 
   See the `at` method of the `Array` type for details. ##}
-pub data ArrayElem E T = { set : T ->[E] Unit }
+pub data ArrayElem E T = { set : T ->[aff E] Unit }
 
 let unsafeGetArray {E, type T} =
   extern dbl_arrayGet : Array E T -> Int ->[aff E] T
@@ -175,7 +175,7 @@ pub method toList {E} (self : Array E _) =
 {# ------------------------------------------------------------------------- #}
 ## ### Creating new arrays
 
-let unsafeInitArray {E} n (f : _ ->[E] _) =
+let unsafeInitArray {E} n (f : _ ->[aff E] _) =
   let arr = unsafeMakeArray {E} n
   let rec loop (i : Int) =
     if i < n then (
@@ -208,7 +208,7 @@ pub method toArray {E, ~mut : Mut E} (self : List _) =
 ##}
 pub method pureInitArray
   {E, ~__line__, ~__file__}
-  (self : Mut E) (n : Int) (f : _ ->[E] _) =
+  (self : Mut E) (n : Int) (f : _ ->[aff E] _) =
     assert {msg="Array of negative size"} (n >= 0);
     unsafeInitArray {E} n f
 

--- a/lib/Mutable.fram
+++ b/lib/Mutable.fram
@@ -77,7 +77,7 @@ pub let ioMut = Mut {E=IO}
 
   The mutability effect can be handled locally, provided that the handled
   computation's effects are affine. ##}
-pub let hMut {type R} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
+pub let hMut {R : effect} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
   handle _ / E = () in
   f {E} Mut
 
@@ -86,7 +86,7 @@ pub let hMut {type R} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
   This function is similar to `hMut`, but it allows the handled expression to
   have other effects. However, this function is not pure: it has the `IO`
   effect. ##}
-pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[aff E, aff R] _) =
+pub let hMutIO {type R} (f : {E : effect} -> Mut E ->[aff E, R] _) =
   f {E=IO} ioMut
 
 {# ========================================================================= #}

--- a/lib/State.fram
+++ b/lib/State.fram
@@ -36,4 +36,3 @@ pub let hState (initial : X) =
   return  x => fn _ => x
   finally c => c initial
   end
-

--- a/lib/State.fram
+++ b/lib/State.fram
@@ -10,8 +10,8 @@ This module provides a standard effect of a single mutable cell.
 
 {## Effect capability representing a single mutable cell of type `X`. ##}
 pub data State E X = State of
-  { get : Unit ->[E] X
-  , set : X ->[E] Unit
+  { get : Unit ->[aff E] X
+  , set : X ->[aff E] Unit
   }
 
 parameter E
@@ -30,9 +30,10 @@ pub method update (cell : State E X) f =
 {## Handler for the `State` effect, initializing the cell with `initial`. ##}
 pub let hState (initial : X) =
   handler State
-    { effect get () = fn st => resume st st
-    , effect set st = fn _  => resume () st
+    { aff effect get () = fn st => resume st st
+    , aff effect set st = fn _  => resume () st
     }
   return  x => fn _ => x
   finally c => c initial
   end
+

--- a/lib/Testing.fram
+++ b/lib/Testing.fram
@@ -96,27 +96,27 @@ data TestLogs  =
 
 {# Tracks state of a test case. Allows "soft" failing. #}
 data TestCaseTracker E =
-  { hardFail  : {X} -> Unit ->[E] X
-  , softFail  : Unit ->[E] Unit
-  , testExit  : {X} -> Unit ->[E] X
+  { hardFail  : {X} -> Unit ->[aff E] X
+  , softFail  : Unit ->[aff E] Unit
+  , testExit  : {X} -> Unit ->[aff E] X
   }
 
 let testCaseTrackerH =
   handler TestCaseTracker
-    { effect softFail _ / r = fn _ => r () TR_Reject
-    , effect hardFail _ / r = fn _ => TR_Reject
-    , effect testExit _     = fn s => s
+    { aff effect softFail _ / r = fn _ => r () TR_Reject
+    , aff effect hardFail _ / r = fn _ => TR_Reject
+    , aff effect testExit _     = fn s => s
     }
     return _ => id
     finally c => c TR_Accept
   end
 
 {# Stores all logs from a test case execution. #}
-data TestLogger E = { log : LogMessage ->[E] Unit }
+data TestLogger E = { log : LogMessage ->[aff E] Unit }
 
 let testLoggerH =
   handler TestLogger
-    { effect log l / r = fn logs => r () (l :: logs) }
+    { aff effect log l / r = fn logs => r () (l :: logs) }
     return s => fn logs => (s, List.rev logs)
     finally c => c ([] : List LogMessage)
   end
@@ -130,17 +130,14 @@ let mkTestCase
     (name : String)
     (f : { E_TL : effect
          , E_TT : effect
-         , E_M  : effect
-         , ~mut : M.Mut E_M
-         , ~testLogger : TestLogger E_TL
-         , ~testCaseTracker : TestCaseTracker E_TT
-         } -> Unit ->[E_TL, E_TT, E_M] Unit) =
+         , ~testLogger : TestLogger (aff E_TL)
+         , ~testCaseTracker : TestCaseTracker (aff E_TT)
+         } -> Unit ->[aff E_TL, aff E_TT] Unit) =
   let loc     = mkLoc
   let body () =
-    M.hMut (fn {E=E_M} ~mut =>
-      handle ~testLogger / E_TL with testLoggerH in
-      handle ~testCaseTracker / E_TT with testCaseTrackerH in
-        f {E_TL, E_TT, E_M} ())
+    handle ~testLogger / E_TL with testLoggerH in
+    handle ~testCaseTracker / E_TT with testCaseTrackerH in
+      f {E_TL, E_TT} ()
   in
   TestCase {name, path=getPath (), loc, body}
 
@@ -317,11 +314,9 @@ pub let testCase
     name
     (f : { E_TL
          , E_TT
-         , E_M
-         , ~mut : M.Mut E_M
-         , ~testLogger : TestLogger E_TL
-         , ~testCaseTracker : TestCaseTracker E_TT
-         } -> Unit ->[E_TL, E_TT, E_M] Unit) =
+         , ~testLogger : TestLogger (aff E_TL)
+         , ~testCaseTracker : TestCaseTracker (aff E_TT)
+         } -> Unit ->[aff E_TL, aff E_TT] Unit) =
   tests := (mkTestCase name f :: tests.get)
 
 let runTest
@@ -459,7 +454,7 @@ section
       { ~__line__
       , ~__file__
       , ?msg : String }
-      (f : {E, ~onError : _ ->[E,_] _} -> Unit ->> _ ) =
+      (f : {E, ~onError : _ ->[aff E,_] _} -> Unit ->> _ ) =
     assertTrue
       {msg = "Assertion Failed: Expected function to call ~onError implicit"}
       (callsOnError f)
@@ -471,7 +466,7 @@ section
       { ~__line__
       , ~__file__
       , ?msg : String }
-      (f : {E, ~onError : _ ->[E,_] _} -> Unit ->> _ ) =
+      (f : {E, ~onError : _ ->[aff E,_] _} -> Unit ->> _ ) =
     assertFalse
       {msg =
         "Assertion Failed: Expected function to not call ~onError implicit"}
@@ -544,7 +539,7 @@ section
       { ~__line__
       , ~__file__
       , ?msg : String }
-      (f : {E, ~onError : _ ->[E,_] _} -> Unit ->> _) =
+      (f : {E, ~onError : _ ->[aff E,_] _} -> Unit ->> _) =
     expectTrue
       {msg = "Expectation Failed: Expected function to call ~onError implicit"}
       (callsOnError f)
@@ -556,7 +551,7 @@ section
       { ~__line__
       , ~__file__
       , ?msg : String }
-      (f : {E, ~onError : _ ->[E,_] _} -> Unit ->> _) =
+      (f : {E, ~onError : _ ->[aff E,_] _} -> Unit ->> _) =
     expectFalse
       {msg =
         "Expectation Failed: Expected function to not call ~onError implicit"}

--- a/lib/Testing.fram
+++ b/lib/Testing.fram
@@ -130,8 +130,8 @@ let mkTestCase
     (name : String)
     (f : { E_TL : effect
          , E_TT : effect
-         , ~testLogger : TestLogger (aff E_TL)
-         , ~testCaseTracker : TestCaseTracker (aff E_TT)
+         , ~testLogger : TestLogger E_TL
+         , ~testCaseTracker : TestCaseTracker E_TT
          } -> Unit ->[aff E_TL, aff E_TT] Unit) =
   let loc     = mkLoc
   let body () =
@@ -314,8 +314,8 @@ pub let testCase
     name
     (f : { E_TL
          , E_TT
-         , ~testLogger : TestLogger (aff E_TL)
-         , ~testCaseTracker : TestCaseTracker (aff E_TT)
+         , ~testLogger : TestLogger E_TL
+         , ~testCaseTracker : TestCaseTracker E_TT
          } -> Unit ->[aff E_TL, aff E_TT] Unit) =
   tests := (mkTestCase name f :: tests.get)
 

--- a/test/stdlib/Exception.fram
+++ b/test/stdlib/Exception.fram
@@ -1,4 +1,5 @@
 import open Testing
+import open /Mutable
 import open /Exception
 
 let _ = testCase "normal return" (fn _ =>
@@ -22,13 +23,14 @@ let _ = testCase "raise is polymorphic" (fn _ =>
   assertEq result 13)
 
 let _ = testCase "handler executed once" (fn _ =>
-  let count = ~mut.ref 0 in
-  let _ =
-    handle exn with hExn (fn _ => count := count.get + 1) in
+  hMut (fn mut =>
+    let count = mut.ref 0 in
+    let _ =
+      handle exn with hExn (fn _ => count := count.get + 1) in
     exn.raise ();
     exn.raise ()
-  in
-  assertEq count.get 1)
+    in
+    assertEq count.get 1))
 
 let _ = testCase "cascade" (fn _ =>
   let result =

--- a/test/stdlib/Mutable.fram
+++ b/test/stdlib/Mutable.fram
@@ -13,16 +13,17 @@ let hBT =
 let _ = testSuite "refs" (fn _ =>
 
   testCase "usage" (fn _ =>
-    let x = ~mut.ref 0
-    let y = ~mut.ref 1 in
-    assertEqS x.get 0;
-    assertEqS y.get 1;
-    x := 2;
-    assertEqS x.get 2;
-    assertEqS y.get 1;
-    y := 5;
-    assertEqS x.get 2;
-    assertEqS y.get 5);
+    hMut (fn mut =>
+      let x = mut.ref 0
+      let y = mut.ref 1 in
+      assertEqS x.get 0;
+      assertEqS y.get 1;
+      x := 2;
+      assertEqS x.get 2;
+      assertEqS y.get 1;
+      y := 5;
+      assertEqS x.get 2;
+      assertEqS y.get 5));
 
   testCase "purity" (fn _ =>
     let ensurePure (f : _ ->[] _) = f ()
@@ -42,32 +43,34 @@ let _ = testSuite "refs" (fn _ =>
 let _ = testSuite "mutable arrays" (fn _ =>
 
   testCase "usage" (fn _ =>
-    let arr1 = ~mut.pureInitArray 4 id in
-    assertEq arr1.length 4;
-    assertEq (arr1.get 0) 0;
-    assertEq (arr1.get 1) 1;
-    assertEq (arr1.get 2) 2;
-    assertEq (arr1.get 3) 3;
-    arr1.at 2 := 13;
-    assertEq (arr1.get 0) 0;
-    assertEq (arr1.get 2) 13;
-    let arr2 = arr1.clone in
-    assertEq arr2.length 4;
-    arr2.at 1 := 42;
-    assertEq (arr2.get 1) 42;
-    assertEq (arr1.get 1) 1);
+    hMut (fn mut =>
+      let arr1 = mut.pureInitArray 4 id in
+      assertEq arr1.length 4;
+      assertEq (arr1.get 0) 0;
+      assertEq (arr1.get 1) 1;
+      assertEq (arr1.get 2) 2;
+      assertEq (arr1.get 3) 3;
+      arr1.at 2 := 13;
+      assertEq (arr1.get 0) 0;
+      assertEq (arr1.get 2) 13;
+      let arr2 = arr1.clone in
+      assertEq arr2.length 4;
+      arr2.at 1 := 42;
+      assertEq (arr2.get 1) 42;
+      assertEq (arr1.get 1) 1));
 
   testCase "array with backtrack" (fn _ =>
-    let tab =
-      handle bt with hBT in
-      ~mut.initArray 2 (fn _ => bt.flip ())
-    in
-    assertEq tab.length 4;
-    assertTrue (tab.get 0 >.get 0);
-    assertTrue (tab.get 0 >.get 1);
-    assertTrue (tab.get 1 >.get 0);
-    assertFalse (tab.get 1 >.get 1);
-    assertFalse (tab.get 2 >.get 0));
+    hMut (fn mut =>
+      let tab =
+        handle bt with hBT in
+        mut.initArray 2 (fn _ => bt.flip ())
+      in
+      assertEq tab.length 4;
+      assertTrue (tab.get 0 >.get 0);
+      assertTrue (tab.get 0 >.get 1);
+      assertTrue (tab.get 1 >.get 0);
+      assertFalse (tab.get 1 >.get 1);
+      assertFalse (tab.get 2 >.get 0)));
 
   # Example program
   let primes n =
@@ -120,54 +123,57 @@ let _ = testSuite "mutable arrays" (fn _ =>
     assertEq (ptab.get 9) 29);
 
   testCase "methods" (fn _ =>
-    let ca = [1,2,3,4].toConstArray in
-    let testarr = [1,2].toArray in
-    let testarr2 = [3,4].toArray in
-    let lst = ca.toList in
-    let lst2 = testarr.toList in
-    testarr.mapInPlace (fn x => x+1);
-    let testarr3 = testarr.concat testarr2 in
-    let testarr4 = testarr2.reverse in
+    hMut (fn ~mut =>
+      let ca = [1,2,3,4].toConstArray in
+      let testarr = [1,2].toArray in
+      let testarr2 = [3,4].toArray in
+      let lst = ca.toList in
+      let lst2 = testarr.toList in
+      testarr.mapInPlace (fn x => x+1);
+      let testarr3 = testarr.concat testarr2 in
+      let testarr4 = testarr2.reverse in
 
-    assertEq (lst.hdErr {~onError=(fn ()=> 2)}) 1;
-    assertEq (lst2.hdErr {~onError=(fn ()=> 2)}) 1;
-    assertEq (testarr.get 0) 2;
-    assertEq (testarr3.get 2) 3;
-    assertEq (testarr2.foldLeft (fn a x => a-x) 0) (-7);
-    assertEq (testarr2.foldRight(fn x a => a-x) 0) (-7);
-    assertTrue (testarr.exists (fn x => x==2));
-    assertFalse (testarr.forall (fn x => x==2));
-    assertTrue (testarr.forall (fn x => x>0));
-    assertTrue (ca.exists (fn x => x>3 ));
-    assertTrue (ca.forall (fn x => x<5));
-    assertFalse (ca.exists (fn x => x<0));
-    assertFalse (ca.forall (fn x => x>1));
-    assertEq (testarr4.get 0) 4;
-    assertEq (testarr4.get 1) 3;
-    assertEq (testarr3.foldLeft (fn a x => a+x) 0) 12);
+      assertEq (lst.hdErr {~onError=(fn ()=> 2)}) 1;
+      assertEq (lst2.hdErr {~onError=(fn ()=> 2)}) 1;
+      assertEq (testarr.get 0) 2;
+      assertEq (testarr3.get 2) 3;
+      assertEq (testarr2.foldLeft (fn a x => a-x) 0) (-7);
+      assertEq (testarr2.foldRight(fn x a => a-x) 0) (-7);
+      assertTrue (testarr.exists (fn x => x==2));
+      assertFalse (testarr.forall (fn x => x==2));
+      assertTrue (testarr.forall (fn x => x>0));
+      assertTrue (ca.exists (fn x => x>3 ));
+      assertTrue (ca.forall (fn x => x<5));
+      assertFalse (ca.exists (fn x => x<0));
+      assertFalse (ca.forall (fn x => x>1));
+      assertEq (testarr4.get 0) 4;
+      assertEq (testarr4.get 1) 3;
+      assertEq (testarr3.foldLeft (fn a x => a+x) 0) 12));
   
   ())
 
 let _ = testSuite "constArray" (fn _ =>
   testCase "usage" (fn _ =>
-    let arr1 = [0, 1, 2].toArray
-    let v = arr1.get 1
-    let carr = arr1.freeze in
-    assertEq (carr.get 1) v;
-    arr1.at 1 := v + 1;
-    assertEq (carr.get 1) v);
+    hMut (fn ~mut =>
+      let arr1 = [0, 1, 2].toArray
+      let v = arr1.get 1
+      let carr = arr1.freeze in
+      assertEq (carr.get 1) v;
+      arr1.at 1 := v + 1;
+      assertEq (carr.get 1) v));
 
 
   testCase "methods" (fn _ =>
-    let arr0 = [4, 5, 6].toArray in
-    let ca2 = arr0.freeze in
-    let arr1 = arr0.map (fn x=> x+1) in
-    let ca3 = ca2.map (fn x=> x+1) in
+    hMut (fn ~mut =>
+      let arr0 = [4, 5, 6].toArray in
+      let ca2 = arr0.freeze in
+      let arr1 = arr0.map (fn x=> x+1) in
+      let ca3 = ca2.map (fn x=> x+1) in
     
-    assertEq (ca2.foldLeft (fn a x => a-x) 0) (-15);
-    assertEq (ca2.foldRight (fn x a => a-x) 0) (-15);
-    assertEq (arr1.foldLeft (fn a x => a-x) 0) (-18);
-    assertEq (ca3.foldLeft (fn a x => a-x) 0) (-18));
+      assertEq (ca2.foldLeft (fn a x => a-x) 0) (-15);
+      assertEq (ca2.foldRight (fn x a => a-x) 0) (-15);
+      assertEq (arr1.foldLeft (fn a x => a-x) 0) (-18);
+      assertEq (ca3.foldLeft (fn a x => a-x) 0) (-18)));
   
   ())
 


### PR DESCRIPTION
PR adds annotations for affine effects in critical places like Mutable lib and standard effects. This in turn allows to eliminate mutability handler from test framework.